### PR TITLE
spring cache 세팅 및 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,11 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.2.3'
 
+    // spring cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
 }
 

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/config/CacheConfig.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/config/CacheConfig.java
@@ -1,0 +1,44 @@
+package com.LetMeDoWith.LetMeDoWith.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.LetMeDoWith.LetMeDoWith.enums.SocialProvider;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+	@Bean
+	public CacheManager socialProviderPublicKeyCacheManager(RedisConnectionFactory cf) {
+		RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+			.entryTtl(Duration.ofMinutes(1L));// TODO - default TTL
+
+		Map<String, RedisCacheConfiguration> individualConfiguration = new HashMap<>();
+		// TODO - 각 Social Provider 마다 API Refresh Time 고려하여 TTL 설정 변경 필요
+		individualConfiguration.put(SocialProvider.APPLE.getCode(), defaultConfig.entryTtl(Duration.ofMinutes(1L)));
+		individualConfiguration.put(SocialProvider.GOOGLE.getCode(), defaultConfig.entryTtl(Duration.ofMinutes(1L)));
+		individualConfiguration.put(SocialProvider.KAKAO.getCode(), defaultConfig.entryTtl(Duration.ofMinutes(1L)));
+
+		return RedisCacheManager.RedisCacheManagerBuilder
+			.fromConnectionFactory(cf)
+			.cacheDefaults(defaultConfig)
+			.withInitialCacheConfigurations(individualConfiguration)
+			.build();
+	}
+}

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/RedisCacheTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/RedisCacheTest.java
@@ -1,0 +1,67 @@
+package com.LetMeDoWith.LetMeDoWith.common;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import com.LetMeDoWith.LetMeDoWith.common.code.TestRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest
+public class RedisCacheTest {
+
+	@Autowired
+	private TestRepository testRepository;
+
+	@Test
+	void objectTypeCacheSuccessTest() throws InterruptedException {
+
+		//given
+
+		//when
+		TestRepository.TestDto result1 = testRepository.testObject();
+		log.debug(result1.toString());
+		Thread.sleep(2000);
+		TestRepository.TestDto result2 = testRepository.testObject();
+		log.debug(result1.toString());
+
+		//then
+		Assertions.assertThat(result2.val1()).isEqualTo(result1.val1());
+		Assertions.assertThat(result2.val2()).isEqualTo(result1.val2());
+
+	}
+
+	@Test
+	void monoTypeNonBlockCacheSuccessTest() throws InterruptedException {
+
+		//given
+
+		//when
+		testRepository.testMono().subscribe(body -> log.debug(body.toString()));
+		Thread.sleep(2000);
+		testRepository.testMono().subscribe(body -> log.debug(body.toString()));
+
+		//then
+		// Assertions.assertThat(result2.val1()).isEqualTo(result1.val1());
+		// Assertions.assertThat(result2.val2()).isEqualTo(result1.val2());
+
+	}
+
+	@Test
+	void monoTypeBlockCacheSuccessTest() throws InterruptedException {
+
+		//given
+
+		//when
+		TestRepository.TestResponseDto result1 = testRepository.testMono().block();
+		Thread.sleep(2000);
+		TestRepository.TestResponseDto result2 = testRepository.testMono().block();
+
+		//then
+		Assertions.assertThat(result2.toString()).isEqualTo(result1.toString());
+
+	}
+
+}

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/WebClientTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/WebClientTest.java
@@ -1,4 +1,4 @@
-package com.LetMeDoWith.LetMeDoWith.client;
+package com.LetMeDoWith.LetMeDoWith.common;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/code/TestRepository.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/code/TestRepository.java
@@ -1,0 +1,55 @@
+package com.LetMeDoWith.LetMeDoWith.common.code;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+@CacheConfig(cacheNames = "APPLE", cacheManager = "socialProviderPublicKeyCacheManager")
+public class TestRepository {
+
+	private final WebClient webClient;
+
+	private static String testUrl = "https://jsonplaceholder.typicode.com/todos/1";
+
+	private Map<String, Object> store = new HashMap<>();
+
+	@Cacheable(key = "'publicKey-String'")
+	public TestDto testObject() {
+		log.debug(">>>Test Method executed");
+		TestDto testDto = TestDto.builder().val1("value1").val2("value2").build();
+		store.put("testData", testDto);
+		return testDto;
+	}
+
+	@Cacheable(key = "'publicKey-Mono'")
+	public Mono<TestResponseDto> testMono() {
+		log.debug(">>>TestMono Method executed");
+		return webClient.get()
+			.uri(testUrl)
+			.accept(MediaType.APPLICATION_JSON)
+			.retrieve()
+			.onStatus(HttpStatusCode::isError, clientResponse ->
+				clientResponse.bodyToMono(String.class).map(body -> new Exception()))
+			.bodyToMono(TestResponseDto.class);
+	}
+
+
+	@Builder
+	public static record TestDto(String val1, String val2) {}
+
+	public record TestResponseDto(Long userId, Long id, String title, Boolean completed) {}
+}


### PR DESCRIPTION
## PR 체크리스트
Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요 

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?
- [x] 모든 Test 코드를 실행하여 PASS했나요?
- [ ] 포스트맨 API 명세를 작성하였나요?


## PR 타입
PR의 타입을 체크해주세요

<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 픽스 - 이슈 링크 : 
- [x] 신규 기능 개발
- [ ] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [ ] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타


## 코드 변경 이유

- 이슈 링크 : https://far-coconut-eec.notion.site/Spring-Cache-0bf2dc3cdbf9404d9a16e0e1c164d617?pvs=4



## 변경된 사항

**Spring Cache 세팅**
- Social Provider의 공개키 저장을 위한 CacheManger Bean 등록
- 각 Provider마다, TTL 시간 다르게 설정하기 위해 Enum 사용하여 TTL 개별적으로 세팅 가능 At CacheConfig>Manager
- 추후 다른 조회가 많이 발생하는 데이터 캐싱시에, CacheConfig에서 다른 Manager 생성

**Spring Cache 세팅 관련 테스트**
- 상세 테스트 코드 참조
- 클래스 단위로 캐싱설정을 위해 `@CacheConfig(cacheNames = "APPLE", cacheManager ="socialProviderPublicKeyCacheManager")`에 Redis Key Prefix와 CacheConfig에서 생성한 Manager 지정
- 각 메서드마다 캐싱을 위해 `@Cacheable(key = "'publicKey-Mono'")` 사용 / key값은 왼쪽과 같이 하면 `APPLE::publicKey-Mono` 따로 지정하지 않으면 파라미터 값 (`APPLE::{파라미터값}`)이 들어가게됨

## 테스트 방법

- 테스트 코드 참고

## 리뷰어 집중 사항

- @S-J-Kim 공개키 관련 개발시 Redis의 키값은 `{SocialProvider code값}::publicKey`로 지정되도록 캐시값 설정 요망 
- 


## 기타 전달 사항

- 
- 
