### PR TITLE
[TAS-186] 토큰 발급 응답 스펙 변경

### DIFF
--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/auth/dto/AuthTokenVO.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/auth/dto/AuthTokenVO.java
@@ -1,7 +1,19 @@
 package com.LetMeDoWith.LetMeDoWith.application.auth.dto;
 
+import com.LetMeDoWith.LetMeDoWith.domain.auth.RefreshToken;
 import java.time.LocalDateTime;
 
 public record AuthTokenVO(String token, LocalDateTime expireAt) {
-
+    
+    /**
+     * Refresh Token을 AuthTokenVO 타입으로 변환
+     *
+     * @param rtk
+     * @return
+     */
+    public static AuthTokenVO fromRtk(RefreshToken rtk) {
+        return new AuthTokenVO(rtk.getToken(),
+                               LocalDateTime.now().plusSeconds(rtk.getExpireSec()));
+    }
+    
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/auth/dto/CreateTokenResult.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/auth/dto/CreateTokenResult.java
@@ -1,0 +1,37 @@
+package com.LetMeDoWith.LetMeDoWith.application.auth.dto;
+
+import com.LetMeDoWith.LetMeDoWith.domain.auth.RefreshToken;
+
+/**
+ * 토큰 발급 요청에 대한 응답 데이터 모델
+ *
+ * @param atk
+ * @param rtk
+ * @param signupToken
+ */
+public record CreateTokenResult(
+    AuthTokenVO atk,
+    AuthTokenVO rtk,
+    AuthTokenVO signupToken
+) {
+    
+    /**
+     * 일반 토큰 (atk, rtk) 요청 시 응답 포맷
+     *
+     * @param atk
+     * @param rtk
+     * @return
+     */
+    public static CreateTokenResult atkInit(AuthTokenVO atk, RefreshToken rtk) {
+        return new CreateTokenResult(atk,
+                                     AuthTokenVO.fromRtk(rtk),
+                                     null);
+    }
+    
+    /**
+     * 회원가입 완료 시 사용되는 SIGNUP token 요청시 응답 포맷
+     */
+    public static CreateTokenResult stkInit(AuthTokenVO signupToken) {
+        return new CreateTokenResult(null, null, signupToken);
+    }
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/auth/service/AuthService.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/auth/service/AuthService.java
@@ -1,19 +1,19 @@
 package com.LetMeDoWith.LetMeDoWith.application.auth.service;
 
-import com.LetMeDoWith.LetMeDoWith.application.auth.repository.RefreshTokenRepository;
-import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenRefreshResDto;
-import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenResDto;
 import com.LetMeDoWith.LetMeDoWith.application.auth.dto.AuthTokenVO;
-import com.LetMeDoWith.LetMeDoWith.domain.auth.RefreshToken;
-import com.LetMeDoWith.LetMeDoWith.domain.member.Member;
+import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateTokenResult;
+import com.LetMeDoWith.LetMeDoWith.application.auth.provider.AuthTokenProvider;
+import com.LetMeDoWith.LetMeDoWith.application.auth.provider.OidcIdTokenProvider;
+import com.LetMeDoWith.LetMeDoWith.application.auth.repository.RefreshTokenRepository;
+import com.LetMeDoWith.LetMeDoWith.application.member.service.MemberService;
 import com.LetMeDoWith.LetMeDoWith.common.enums.SocialProvider;
 import com.LetMeDoWith.LetMeDoWith.common.enums.common.FailResponseStatus;
 import com.LetMeDoWith.LetMeDoWith.common.enums.member.MemberStatus;
 import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
-import com.LetMeDoWith.LetMeDoWith.application.auth.provider.AuthTokenProvider;
-import com.LetMeDoWith.LetMeDoWith.application.auth.provider.OidcIdTokenProvider;
-import com.LetMeDoWith.LetMeDoWith.application.member.service.MemberService;
 import com.LetMeDoWith.LetMeDoWith.common.util.HeaderUtil;
+import com.LetMeDoWith.LetMeDoWith.domain.auth.RefreshToken;
+import com.LetMeDoWith.LetMeDoWith.domain.member.Member;
+import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenRefreshResDto;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import java.util.Optional;
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Service;
 public class AuthService {
     
     private final AuthTokenProvider authTokenProvider;
-
+    
     private final RefreshTokenRepository refreshTokenRepository;
     
     private final MemberService memberService;
@@ -43,8 +43,8 @@ public class AuthService {
         
         // Redis에서 RTK info 조회
         RefreshToken savedRefreshToken = refreshTokenRepository.getRefreshToken(refreshToken)
-                                                                    .orElseThrow(() -> new RestApiException(
-                                                                        FailResponseStatus.TOKEN_EXPIRED_BY_ADMIN));
+                                                               .orElseThrow(() -> new RestApiException(
+                                                                   FailResponseStatus.TOKEN_EXPIRED_BY_ADMIN));
         
         // RTK 추가 보안 점검
         if (!savedRefreshToken.getMemberId().equals(memberId)) {
@@ -81,7 +81,7 @@ public class AuthService {
      * @param idToken
      * @return 기 가입되어 있는 경우 ATK, 아닌 경우 회원가입 프로세스로 fallback.
      */
-    public CreateTokenResDto createToken(SocialProvider socialProvider, String idToken) {
+    public CreateTokenResult createToken(SocialProvider socialProvider, String idToken) {
         Jws<Claims> verifiedIdToken = oidcIdTokenProvider.getVerifiedOidcIdToken(socialProvider,
                                                                                  idToken);
         
@@ -103,7 +103,7 @@ public class AuthService {
      * @param member 토큰을 발급하려는 (로그인하려는) 멤버
      * @return access token 및 refresh token.
      */
-    public CreateTokenResDto getToken(Member member) {
+    public CreateTokenResult getToken(Member member) {
         
         if (member.getStatus().equals(MemberStatus.NORMAL)) {
             AuthTokenVO accessToken = authTokenProvider.createAccessToken(member.getId());
@@ -111,10 +111,7 @@ public class AuthService {
                                                                              accessToken.token(),
                                                                              HeaderUtil.getUserAgent());
             
-            return CreateTokenResDto.builder()
-                                    .atk(accessToken)
-                                    .rtk(refreshToken)
-                                    .build();
+            return CreateTokenResult.atkInit(accessToken, refreshToken);
         } else {
             throw new RestApiException(member.getStatus().getApiResponseStatus());
         }
@@ -126,14 +123,12 @@ public class AuthService {
      * <p>
      * 이후 회원가입이 완료될 때 Client에서 넘어오는 정보를 가지고 임시 Member를 업데이트한다.
      */
-    private CreateTokenResDto createTemporalMember(SocialProvider provider, String subject) {
+    private CreateTokenResult createTemporalMember(SocialProvider provider, String subject) {
         log.info("Not registered user!");
         Member member = memberService.createSocialAuthenticatedMember(provider,
                                                                       subject);
         
-        return CreateTokenResDto.builder()
-                                .signupToken(authTokenProvider.createSignupToken(member.getId()))
-                                .build();
+        return CreateTokenResult.stkInit(authTokenProvider.createSignupToken(member.getId()));
     }
     
     

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/controller/AuthController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/controller/AuthController.java
@@ -1,13 +1,14 @@
 package com.LetMeDoWith.LetMeDoWith.presentation.auth.controller;
 
+import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateTokenResult;
+import com.LetMeDoWith.LetMeDoWith.application.auth.service.AuthService;
+import com.LetMeDoWith.LetMeDoWith.common.enums.common.SuccessResponseStatus;
+import com.LetMeDoWith.LetMeDoWith.common.util.HeaderUtil;
+import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
 import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateAccessTokenReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenRefreshReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenRefreshResDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenResDto;
-import com.LetMeDoWith.LetMeDoWith.common.enums.common.SuccessResponseStatus;
-import com.LetMeDoWith.LetMeDoWith.application.auth.service.AuthService;
-import com.LetMeDoWith.LetMeDoWith.common.util.HeaderUtil;
-import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,7 +39,7 @@ public class AuthController {
     public ResponseEntity createToken(
         @RequestBody CreateAccessTokenReqDto createAccessTokenReqDto) {
         
-        CreateTokenResDto tokenRequestResult = authService.createToken(
+        CreateTokenResult tokenRequestResult = authService.createToken(
             createAccessTokenReqDto.provider(),
             createAccessTokenReqDto.idToken()
         );
@@ -47,6 +48,6 @@ public class AuthController {
             tokenRequestResult.signupToken() == null
                 ? SuccessResponseStatus.LOGIN_SUCCESS
                 : SuccessResponseStatus.PROCEED_TO_SIGNUP
-            , tokenRequestResult);
+            , CreateTokenResDto.fromCreateTokenResult(tokenRequestResult));
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/dto/CreateTokenResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/dto/CreateTokenResDto.java
@@ -1,10 +1,17 @@
 package com.LetMeDoWith.LetMeDoWith.presentation.auth.dto;
 
 import com.LetMeDoWith.LetMeDoWith.application.auth.dto.AuthTokenVO;
-import com.LetMeDoWith.LetMeDoWith.domain.auth.RefreshToken;
+import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateTokenResult;
 import lombok.Builder;
 
 @Builder
-public record CreateTokenResDto(AuthTokenVO atk, RefreshToken rtk, AuthTokenVO signupToken) {
-
+public record CreateTokenResDto(AuthTokenVO atk, AuthTokenVO rtk, AuthTokenVO signupToken) {
+    
+    public static CreateTokenResDto fromCreateTokenResult(CreateTokenResult result) {
+        return CreateTokenResDto.builder()
+                                .atk(result.atk())
+                                .rtk(result.rtk())
+                                .signupToken(result.signupToken())
+                                .build();
+    }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberController.java
@@ -1,16 +1,17 @@
 package com.LetMeDoWith.LetMeDoWith.presentation.member.controller;
 
+import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateTokenResult;
+import com.LetMeDoWith.LetMeDoWith.application.auth.service.AuthService;
 import com.LetMeDoWith.LetMeDoWith.application.member.dto.CreateSignupCompletedMemberCommand;
-import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.CreateMemberTermAgreeReqDto;
-import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.SignupCompleteReqDto;
-import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenResDto;
-import com.LetMeDoWith.LetMeDoWith.domain.member.Member;
+import com.LetMeDoWith.LetMeDoWith.application.member.service.MemberService;
 import com.LetMeDoWith.LetMeDoWith.common.enums.common.FailResponseStatus;
 import com.LetMeDoWith.LetMeDoWith.common.enums.common.SuccessResponseStatus;
 import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
-import com.LetMeDoWith.LetMeDoWith.application.auth.service.AuthService;
-import com.LetMeDoWith.LetMeDoWith.application.member.service.MemberService;
 import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
+import com.LetMeDoWith.LetMeDoWith.domain.member.Member;
+import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.CreateMemberTermAgreeReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.SignupCompleteReqDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,22 +43,24 @@ public class MemberController {
                                               .dateOfBirth(signupCompleteReqDto.dateOfBirth())
                                               .gender(signupCompleteReqDto.gender())
                                               .isTerms(signupCompleteReqDto.agreements()
-                                                                        .termsOfAgree())
-                                              .isPrivacy(signupCompleteReqDto.agreements().privacy())
+                                                                           .termsOfAgree())
+                                              .isPrivacy(signupCompleteReqDto.agreements()
+                                                                             .privacy())
                                               .isAdvertisement(signupCompleteReqDto.agreements()
-                                                                                .advertisement())
+                                                                                   .advertisement())
                                               .build();
         
         Member signupCompletedMember = memberService.createSignupCompletedMember(command);
-        CreateTokenResDto token = authService.getToken(signupCompletedMember);
+        CreateTokenResult token = authService.getToken(signupCompletedMember);
         
-        return ResponseUtil.createSuccessResponse(SuccessResponseStatus.LOGIN_SUCCESS, token);
+        return ResponseUtil.createSuccessResponse(SuccessResponseStatus.LOGIN_SUCCESS,
+                                                  CreateTokenResDto.fromCreateTokenResult(token));
     }
     
     /**
      * 멤버의 약관 동의 사항을 생성한다.
      *
-     * @param memberId                 약관동의를 생성할 멤버
+     * @param memberId                    약관동의를 생성할 멤버
      * @param createMemberTermAgreeReqDto 멤버의 약관 동의 사항. 필수 동의사항은 false일 수 없다.
      * @return 성공 메세지
      */


### PR DESCRIPTION
## PR 체크리스트
Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요 

- [ ] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?
- [x] 모든 Test 코드를 실행하여 PASS했나요?
- [x] 포스트맨 API 명세를 작성하였나요?


## PR 타입
PR의 타입을 체크해주세요

<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 픽스 - 이슈 링크 : 
- [ ] 신규 기능 개발
- [x] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [ ] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타


## 코드 변경 이유

- 이슈 링크 : https://far-coconut-eec.notion.site/API-f982c8ee1c994a51a9e1fa8b140c387f?pvs=4



## 변경된 사항

-  토큰 응답 시 RTK에 자잘한 정보들이 포함되서 응답이 나갔는데, ATK와 동일하게 `token` 및 `expireAt` 필드만 응답하도록 변경함
- 토큰 발급 시 관여하는 Service -> Controller 간 통신(토큰 리턴)에 `CreateTokenResult` 사용하도록 변경함

## 테스트 방법

-
-

## 리뷰어 집중 사항

- 
- 


## 기타 전달 사항

- 
- 
