### PR TITLE
[TAS-308] Swagger 명세

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ out/
 ### Dev server artifacts ###
 samLocalEnvVars.json
 .aws-sam/
+*.env
 
 /.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ configurations {
 
 // 환경변수 설정
 ext {
-    awsCliProfile= System.getenv("AWS_CLI_PROFILE")
+    awsCliProfile = System.getenv("AWS_CLI_PROFILE")
     dockerImageName = System.getenv("DOCKER_IMAGE_NAME")
     dockerImageTag = System.getenv("DOCKER_IMAGE_TAG")
     ecrRepository = System.getenv("ECR_REPOSITORY")
@@ -82,13 +82,14 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    annotationProcessor 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
-    // swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
 }
 
-import com.bmuschko.gradle.docker.tasks.image.*
+
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+import com.bmuschko.gradle.docker.tasks.image.DockerTagImage
 
 task buildDockerImage(type: DockerBuildImage) {
     group = "docker"

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/auth/dto/AuthTokenVO.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/auth/dto/AuthTokenVO.java
@@ -3,9 +3,16 @@ package com.LetMeDoWith.LetMeDoWith.application.auth.dto;
 import com.LetMeDoWith.LetMeDoWith.domain.auth.model.AccessToken;
 import com.LetMeDoWith.LetMeDoWith.domain.auth.model.RefreshToken;
 import com.LetMeDoWith.LetMeDoWith.domain.auth.model.SignupToken;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
-public record AuthTokenVO(String token, LocalDateTime expireAt) {
+@Schema(description = "인증 과정에서 사용되는 토큰")
+public record AuthTokenVO(
+    @Schema(description = "토큰 본문")
+    String token,
+    
+    @Schema(description = "토큰 만료시기")
+    LocalDateTime expireAt) {
     
     /**
      * Refresh Token을 AuthTokenVO 타입으로 변환
@@ -17,11 +24,11 @@ public record AuthTokenVO(String token, LocalDateTime expireAt) {
         return new AuthTokenVO(rtk.getToken(),
                                LocalDateTime.now().plusSeconds(rtk.getExpireSec()));
     }
-
+    
     public static AuthTokenVO from(AccessToken atk) {
         return new AuthTokenVO(atk.getToken(), atk.getExpireAt());
     }
-
+    
     public static AuthTokenVO from(SignupToken signUpToken) {
         return new AuthTokenVO(signUpToken.getToken(), signUpToken.getExpireAt());
     }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/annotation/ApiErrorResponse.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/annotation/ApiErrorResponse.java
@@ -1,0 +1,18 @@
+package com.LetMeDoWith.LetMeDoWith.common.annotation;
+
+import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Repeatable(ApiErrorResponses.class)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorResponse {
+    
+    FailResponseStatus status();
+    
+    String description() default "";
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/annotation/ApiErrorResponses.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/annotation/ApiErrorResponses.java
@@ -1,11 +1,9 @@
 package com.LetMeDoWith.LetMeDoWith.common.annotation;
 
-import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 
 /**
  * Swagger API Docs에서 각 Endpoint 별 응답 가능한 Error 목록을 표시하기 위한 Annotation.
@@ -15,5 +13,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiErrorResponses {
     
-    FailResponseStatus[] errors() default {};
+    ApiErrorResponse[] value() default {};
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/annotation/ApiErrorResponses.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/annotation/ApiErrorResponses.java
@@ -1,0 +1,19 @@
+package com.LetMeDoWith.LetMeDoWith.common.annotation;
+
+import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Swagger API Docs에서 각 Endpoint 별 응답 가능한 Error 목록을 표시하기 위한 Annotation.
+ * 각 Endpoint에 본 애너테이션을 사용하여 FailResponseStatus를 지정하는 것 만으로도 Swagger Docs에 에러 Example이 생성된다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorResponses {
+    
+    FailResponseStatus[] errors() default {};
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/annotation/ApiSuccessResponse.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/annotation/ApiSuccessResponse.java
@@ -1,0 +1,18 @@
+package com.LetMeDoWith.LetMeDoWith.common.annotation;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "200",
+    useReturnTypeSchema = true
+)
+public @interface ApiSuccessResponse {
+    
+    String description() default "";
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/dto/ResponseDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/dto/ResponseDto.java
@@ -1,11 +1,14 @@
 package com.LetMeDoWith.LetMeDoWith.common.dto;
 
-import lombok.AllArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import lombok.Getter;
 
 
 @Builder
-public record ResponseDto<T>(String statusCode, String message, T data) {
-
+@Schema(description = "요청에 대한 응답 스키마")
+public record ResponseDto<T>(
+    String statusCode,
+    String message,
+    T data) {
+    
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/enums/member/Gender.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/enums/member/Gender.java
@@ -1,8 +1,9 @@
 package com.LetMeDoWith.LetMeDoWith.common.enums.member;
 
-import com.LetMeDoWith.LetMeDoWith.common.enums.BaseEnum;
 import com.LetMeDoWith.LetMeDoWith.common.converter.member.GenderConverter;
+import com.LetMeDoWith.LetMeDoWith.common.enums.BaseEnum;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,6 +11,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 @JsonDeserialize(using = GenderConverter.class)
+@Schema(enumAsRef = true)
 public enum Gender implements BaseEnum {
     MALE("M", "남성"),
     FEMALE("F", "여성");

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/exception/status/FailResponseStatus.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/exception/status/FailResponseStatus.java
@@ -61,52 +61,51 @@ public enum FailResponseStatus {
                        "E219",
                        HttpStatus.BAD_REQUEST,
                        "이미 존재하는 닉네임입니다"),
-
+    
     // Badge 도메인 관련 Exception - E22X
     MEMBER_CANNOT_WITHDRAW("MEMBER_CANNOT_WITHDRAW",
-        "E220",
-        HttpStatus.BAD_REQUEST,
-        "회원을 찾을 수 없습니다. 이미 탈퇴하였거나 회원가입이 완료되지 않았습니다."),
+                           "E220",
+                           HttpStatus.BAD_REQUEST,
+                           "회원을 찾을 수 없습니다. 이미 탈퇴하였거나 회원가입이 완료되지 않았습니다."),
     MEMBER_NOT_EXIST_BADGE("MEMBER_BADGE_NOT_EXIST",
-                        "E220",
-                        HttpStatus.BAD_REQUEST,
-                        "뱃지 관련 작업 수행을 위한 회원이 존재하지 않습니다."),
+                           "E220",
+                           HttpStatus.BAD_REQUEST,
+                           "뱃지 관련 작업 수행을 위한 회원이 존재하지 않습니다."),
     BADGE_NOT_EXIST("BADGE_NOT_EXIST",
-                        "E221",
-                        HttpStatus.BAD_REQUEST,
-                        "해당 뱃지가 존재하지 않습니다"),
+                    "E221",
+                    HttpStatus.BAD_REQUEST,
+                    "해당 뱃지가 존재하지 않습니다"),
     LAZY_NOT_AVAIL_UPDATE_MAIN_BADGE("LAZY_NOT_AVAIL_UPDATE_MAIN_BADGE",
-                        "E222",
-                        HttpStatus.BAD_REQUEST,
-                        "레이지 뱃지를 받은 회원은 대표 뱃지를 설정할 수 없습니다."),
+                                     "E222",
+                                     HttpStatus.BAD_REQUEST,
+                                     "레이지 뱃지를 받은 회원은 대표 뱃지를 설정할 수 없습니다."),
     MEMBER_BADGE_NOT_EXIST("MEMBER_BADGE_NOT_EXIST",
-                        "E223",
-                        HttpStatus.BAD_REQUEST,
-                        "획득하지 않은 뱃지입니다"),
-
+                           "E223",
+                           HttpStatus.BAD_REQUEST,
+                           "획득하지 않은 뱃지입니다"),
+    
     // Dowith Task 관련 Exception - E23X
     DOWITH_TASK_CREATE_COUNT_EXCEED("DOWITH_TASK_CREATE_COUNT_EXCEED",
-                                "E230",
-                                HttpStatus.BAD_REQUEST,
-                                "일일 등록 가능한 두윗모드 갯수를 초과하였습니다."),
+                                    "E230",
+                                    HttpStatus.BAD_REQUEST,
+                                    "일일 등록 가능한 두윗모드 갯수를 초과하였습니다."),
     DOWITH_TASK_UPDATE_NOT_AVAIL("DOWITH_TASK_UPDATE_NOT_AVAIL",
-                                "E231",
-                                HttpStatus.BAD_REQUEST,
-                                "수정이 불가합니다."),
+                                 "E231",
+                                 HttpStatus.BAD_REQUEST,
+                                 "수정이 불가합니다."),
     DOWITH_TASK_NOT_EXIST("DOWITH_TASK_NOT_EXIST",
-                                "E232",
-                                HttpStatus.BAD_REQUEST,
-                                "존재하지 않는 두윗모드 테스크입니다."),
+                          "E232",
+                          HttpStatus.BAD_REQUEST,
+                          "존재하지 않는 두윗모드 테스크입니다."),
     DOWITH_TASK_NOT_AVAIL_START_TIME("DOWITH_TASK_NOT_AVAIL_START_TIME",
-                                        "E243",
-                                HttpStatus.BAD_REQUEST,
-                                "등록 불가한 시작시간입니다."),
+                                     "E243",
+                                     HttpStatus.BAD_REQUEST,
+                                     "등록 불가한 시작시간입니다."),
     DOWITH_TASK_NOT_AVAIL_DATE("DOWITH_TASK_NOT_AVAIL_START_TIME",
-        "E243",
-        HttpStatus.BAD_REQUEST,
-        "등록 불가한 날짜입니다."),
-
-
+                               "E243",
+                               HttpStatus.BAD_REQUEST,
+                               "등록 불가한 날짜입니다."),
+    
     /**
      * 401 UnAuthorized Error 인증 관련 오류
      */
@@ -118,7 +117,10 @@ public enum FailResponseStatus {
                            HttpStatus.UNAUTHORIZED,
                            "만료된 토큰입니다."),
     INVALID_TOKEN("INVALID_TOKEN", "E304", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
-    INVALID_JWT_TOKEN_FORMAT("INVALID_JWT_TOKEN_FORMAT", "E305", HttpStatus.UNAUTHORIZED, "올바르지 않은 JWT 토큰입니다."),
+    INVALID_JWT_TOKEN_FORMAT("INVALID_JWT_TOKEN_FORMAT",
+                             "E305",
+                             HttpStatus.UNAUTHORIZED,
+                             "올바르지 않은 JWT 토큰입니다."),
     INVALID_RTK_TOKEN_MEMBER_NOT_MATCHED("INVALID_RTK_TOKEN_MEMBER_NOT_MATCHED",
                                          "E306",
                                          HttpStatus.UNAUTHORIZED,
@@ -127,15 +129,15 @@ public enum FailResponseStatus {
                                       "E307",
                                       HttpStatus.UNAUTHORIZED,
                                       "유효하지 않은 토큰 소유자입니다."), // TODO - ALERT 대상
-    INVALID_RTK_TOKEN_USER_AGENT_NOT_MATCHED("INVALID_RTK_TOKEN_ATK_NOT_MATCHED",
-        "E308",
-        HttpStatus.UNAUTHORIZED,
-        "유효하지 않은 토큰 소유자입니다."), // TODO - ALERT 대상
+    INVALID_RTK_TOKEN_USER_AGENT_NOT_MATCHED("INVALID_RTK_TOKEN_USER_AGENT_NOT_MATCHED",
+                                             "E308",
+                                             HttpStatus.UNAUTHORIZED,
+                                             "유효하지 않은 토큰 소유자입니다."), // TODO - ALERT 대상
     OIDC_ID_TOKEN_PUBKEY_NOT_FOUND("OIDC_ID_TOKEN_PUBKEY_NOT_FOUND",
                                    "E309",
                                    HttpStatus.UNAUTHORIZED,
                                    "OpenID Connect ID Token의 공개키를 찾을 수 없습니다."),
-
+    
     /**
      * 500 Interal Server Error 서버 내부 오류 및 서버 관리자의 조치로 인한 오류
      */
@@ -146,7 +148,7 @@ public enum FailResponseStatus {
     CODE_ENUM_NOT_EXIST("CODE_ENUM_NOT_EXIST",
                         "E401",
                         HttpStatus.INTERNAL_SERVER_ERROR,
-                "코드에 대응되는 Enum이 존재하지 않습니다.");
+                        "코드에 대응되는 Enum이 존재하지 않습니다.");
     
     private final String statusName;
     private final String statusCode;

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/auth/enums/SocialProvider.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/auth/enums/SocialProvider.java
@@ -5,6 +5,7 @@ import com.LetMeDoWith.LetMeDoWith.common.enums.BaseEnum;
 import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
 import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @JsonDeserialize(using = SocialProviderConverter.class)
+@Schema(enumAsRef = true)
 public enum SocialProvider implements BaseEnum {
     
     KAKAO("KAKAO", "카카오", "https://kauth.kakao.com"),

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/controller/AuthController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateRefreshTokenResult
 import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateTokenResult;
 import com.LetMeDoWith.LetMeDoWith.application.auth.provider.AccessTokenProvider;
 import com.LetMeDoWith.LetMeDoWith.application.auth.service.CreateTokenService;
+import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponse;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponses;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiSuccessResponse;
 import com.LetMeDoWith.LetMeDoWith.common.dto.ResponseDto;
@@ -41,12 +42,22 @@ public class AuthController {
     
     @Operation(summary = "토큰 재발급", description = "새로운 AccessToken과 RefreshToken을 발급 받습니다.")
     @ApiSuccessResponse(description = "토큰 재 발급 성공")
-    @ApiErrorResponses(errors = {
-        FailResponseStatus.INVALID_JWT_TOKEN_FORMAT,
-        FailResponseStatus.TOKEN_EXPIRED_BY_ADMIN,
-        FailResponseStatus.INVALID_RTK_TOKEN_MEMBER_NOT_MATCHED,
-        FailResponseStatus.INVALID_RTK_TOKEN_ATK_NOT_MATCHED,
-        FailResponseStatus.INVALID_RTK_TOKEN_USER_AGENT_NOT_MATCHED
+    @ApiErrorResponses({
+        @ApiErrorResponse(
+            status = FailResponseStatus.INVALID_JWT_TOKEN_FORMAT,
+            description = "ATK가 올바른 JWT 형식이 아닐 때 발생"),
+        @ApiErrorResponse(
+            status = FailResponseStatus.TOKEN_EXPIRED_BY_ADMIN,
+            description = "ATK가 운영자에 의해 강제로 만료됨. 재시도 필요"),
+        @ApiErrorResponse(
+            status = FailResponseStatus.INVALID_RTK_TOKEN_MEMBER_NOT_MATCHED,
+            description = "RTK의 소유자가 일치하지 않을 때 발생"),
+        @ApiErrorResponse(
+            status = FailResponseStatus.INVALID_RTK_TOKEN_ATK_NOT_MATCHED,
+            description = "서로 다른 시점에 발급돤 RTK와 ATK로 요청했을 때 발생"),
+        @ApiErrorResponse(
+            status = FailResponseStatus.INVALID_RTK_TOKEN_USER_AGENT_NOT_MATCHED,
+            description = "토큰 발급 시 사용된 User-Agent와 다른 User-Agent로 요청했을 때 발생"),
     })
     @PostMapping("/token/refresh")
     public ResponseEntity<ResponseDto<CreateRefreshTokenResDto>> createTokenRefresh(
@@ -64,7 +75,11 @@ public class AuthController {
     
     @Operation(summary = "토큰 발급", description = "소셜 로그인 idToken을 통해 AccessToken과 RefreshToken을 발급 받습니다. Provider : KAKAO - 카카오 / GOOGLE - 구글 / APPLE - 애플 / DEV_KAKAO - 카카오 (개발서버 전용)")
     @ApiSuccessResponse(description = "토큰발급 성공. 이미 존재하는 회원일 때는 singupToken 필드가, 회원가입이 필요한 경우 atk, rtk 필드가 null로 설정됩니다.")
-    @ApiErrorResponses(errors = {FailResponseStatus.OIDC_ID_TOKEN_PUBKEY_NOT_FOUND})
+    @ApiErrorResponses({
+        @ApiErrorResponse(
+            status = FailResponseStatus.OIDC_ID_TOKEN_PUBKEY_NOT_FOUND,
+            description = "OIDC ID Token의 Public Key를 찾을 수 없을 때 발생. Social Provider의 인증서버 문제의 가능성이 높음"),
+    })
     @PostMapping("/token")
     public ResponseEntity<ResponseDto<CreateTokenResDto>> createToken(
         @RequestBody CreateTokenReqDto createTokenReqDto) {
@@ -83,7 +98,11 @@ public class AuthController {
     
     @Operation(summary = "개발 환경 임시 토큰 발급", description = "개발 환경용 임시 토큰 발급")
     @ApiSuccessResponse(description = "개발 환경용 토큰 발급 성공")
-    @ApiErrorResponses(errors = {FailResponseStatus.UNAUTHORIZED})
+    @ApiErrorResponses({
+        @ApiErrorResponse(
+            status = FailResponseStatus.UNAUTHORIZED,
+            description = "개발용 인증을 위한 id, pw를 올바르게 입력하지 않았을 때 발생")
+    })
     @PostMapping("/token/temp")
     public ResponseEntity<ResponseDto<CreateTokenTempResDto>> createTokenTemp(
         @RequestBody CreateTokenTempReqDto requestBody

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/controller/AuthController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/controller/AuthController.java
@@ -1,24 +1,26 @@
 package com.LetMeDoWith.LetMeDoWith.presentation.auth.controller;
 
 import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateRefreshTokenResult;
+import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateTokenResult;
 import com.LetMeDoWith.LetMeDoWith.application.auth.provider.AccessTokenProvider;
+import com.LetMeDoWith.LetMeDoWith.application.auth.service.CreateTokenService;
+import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponses;
+import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiSuccessResponse;
+import com.LetMeDoWith.LetMeDoWith.common.dto.ResponseDto;
 import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
 import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
-import com.LetMeDoWith.LetMeDoWith.common.util.AuthUtil;
-import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateTokenResult;
-import com.LetMeDoWith.LetMeDoWith.application.auth.service.CreateTokenService;
 import com.LetMeDoWith.LetMeDoWith.common.exception.status.SuccessResponseStatus;
+import com.LetMeDoWith.LetMeDoWith.common.util.AuthUtil;
 import com.LetMeDoWith.LetMeDoWith.common.util.HeaderUtil;
 import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
 import com.LetMeDoWith.LetMeDoWith.domain.auth.model.AccessToken;
-import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenReqDto;
-import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenRefreshReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateRefreshTokenResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenRefreshReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenResDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenTempReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenTempResDto;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -34,26 +36,37 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     
     private final CreateTokenService createTokenService;
-
+    
     private final AccessTokenProvider accessTokenProvider;
-
+    
     @Operation(summary = "토큰 재발급", description = "새로운 AccessToken과 RefreshToken을 발급 받습니다.")
+    @ApiSuccessResponse(description = "토큰 재 발급 성공")
+    @ApiErrorResponses(errors = {
+        FailResponseStatus.INVALID_JWT_TOKEN_FORMAT,
+        FailResponseStatus.TOKEN_EXPIRED_BY_ADMIN,
+        FailResponseStatus.INVALID_RTK_TOKEN_MEMBER_NOT_MATCHED,
+        FailResponseStatus.INVALID_RTK_TOKEN_ATK_NOT_MATCHED,
+        FailResponseStatus.INVALID_RTK_TOKEN_USER_AGENT_NOT_MATCHED
+    })
     @PostMapping("/token/refresh")
-    public ResponseEntity createTokenRefresh(@RequestBody CreateTokenRefreshReqDto requestBody) {
+    public ResponseEntity<ResponseDto<CreateRefreshTokenResDto>> createTokenRefresh(
+        @RequestBody CreateTokenRefreshReqDto requestBody) {
         
         String userAgent = HeaderUtil.getUserAgent();
         String accessToken = AuthUtil.getAccessToken();
-
+        
         CreateRefreshTokenResult result = createTokenService.createRefreshToken(accessToken,
-            requestBody.refreshToken(),
-            userAgent);
-
+                                                                                requestBody.refreshToken(),
+                                                                                userAgent);
+        
         return ResponseUtil.createSuccessResponse(CreateRefreshTokenResDto.of(result));
     }
-
-    @Operation(summary = "토큰 발급", description = "소셜 로그인 idToken을 통해 AccessToken과 RefreshToken을 발급 받습니다. Provider : KAKAO - 카카오 / GOOGLE - 구글 / APPLE - 애플")
+    
+    @Operation(summary = "토큰 발급", description = "소셜 로그인 idToken을 통해 AccessToken과 RefreshToken을 발급 받습니다. Provider : KAKAO - 카카오 / GOOGLE - 구글 / APPLE - 애플 / DEV_KAKAO - 카카오 (개발서버 전용)")
+    @ApiSuccessResponse(description = "토큰발급 성공. 이미 존재하는 회원일 때는 singupToken 필드가, 회원가입이 필요한 경우 atk, rtk 필드가 null로 설정됩니다.")
+    @ApiErrorResponses(errors = {FailResponseStatus.OIDC_ID_TOKEN_PUBKEY_NOT_FOUND})
     @PostMapping("/token")
-    public ResponseEntity createToken(
+    public ResponseEntity<ResponseDto<CreateTokenResDto>> createToken(
         @RequestBody CreateTokenReqDto createTokenReqDto) {
         
         CreateTokenResult createTokenResultRequestResult = createTokenService.createToken(
@@ -67,23 +80,25 @@ public class AuthController {
                 : SuccessResponseStatus.PROCEED_TO_SIGNUP
             , CreateTokenResDto.fromCreateTokenResult(createTokenResultRequestResult));
     }
-
+    
     @Operation(summary = "개발 환경 임시 토큰 발급", description = "개발 환경용 임시 토큰 발급")
+    @ApiSuccessResponse(description = "개발 환경용 토큰 발급 성공")
+    @ApiErrorResponses(errors = {FailResponseStatus.UNAUTHORIZED})
     @PostMapping("/token/temp")
-    public ResponseEntity createTokenTemp(
+    public ResponseEntity<ResponseDto<CreateTokenTempResDto>> createTokenTemp(
         @RequestBody CreateTokenTempReqDto requestBody
     ) {
         String id = "admin0114";
         String password = "dev-letmedowith";
-
+        
         AccessToken accessToken = null;
-        if(requestBody.id().equals(id) && requestBody.password().equals(password)) {
+        if (requestBody.id().equals(id) && requestBody.password().equals(password)) {
             accessToken = accessTokenProvider.createAccessToken(
                 requestBody.memberId());
-        }else {
+        } else {
             throw new RestApiException(FailResponseStatus.UNAUTHORIZED);
         }
-
+        
         return ResponseUtil.createSuccessResponse(new CreateTokenTempResDto(accessToken.getToken()));
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/dto/CreateTokenReqDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/dto/CreateTokenReqDto.java
@@ -1,7 +1,14 @@
 package com.LetMeDoWith.LetMeDoWith.presentation.auth.dto;
 
 import com.LetMeDoWith.LetMeDoWith.domain.auth.enums.SocialProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record CreateTokenReqDto(SocialProvider provider, String idToken) {
-
+@Schema(description = "token 발급 요청")
+public record CreateTokenReqDto(
+    @Schema(description = "소셜 공급자", implementation = SocialProvider.class)
+    SocialProvider provider,
+    
+    @Schema(description = "자격증명 제공자로부터 발급받은 OIDC Id Token")
+    String idToken) {
+    
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/dto/CreateTokenResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/dto/CreateTokenResDto.java
@@ -2,10 +2,20 @@ package com.LetMeDoWith.LetMeDoWith.presentation.auth.dto;
 
 import com.LetMeDoWith.LetMeDoWith.application.auth.dto.AuthTokenVO;
 import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateTokenResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record CreateTokenResDto(AuthTokenVO atk, AuthTokenVO rtk, AuthTokenVO signupToken) {
+@Schema(description = "토큰 발급 요청의 결과")
+public record CreateTokenResDto(
+    @Schema(description = "API 요청에 사용되는 Token", implementation = AuthTokenVO.class)
+    AuthTokenVO atk,
+    
+    @Schema(description = "ATK 재발급에 사용되는 Token", implementation = AuthTokenVO.class)
+    AuthTokenVO rtk,
+    
+    @Schema(description = "회원가입 검증에 사용되는 Token", implementation = AuthTokenVO.class)
+    AuthTokenVO signupToken) {
     
     public static CreateTokenResDto fromCreateTokenResult(CreateTokenResult result) {
         return CreateTokenResDto.builder()

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/config/SwaggerConfig.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/config/SwaggerConfig.java
@@ -1,33 +1,112 @@
 package com.LetMeDoWith.LetMeDoWith.presentation.config;
 
-import io.swagger.v3.core.util.OpenAPI30To31;
+import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponses;
+import com.LetMeDoWith.LetMeDoWith.common.dto.FailResponseDto;
+import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.In;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.method.HandlerMethod;
 
 @Configuration
+@Slf4j
 public class SwaggerConfig {
-
-  @Bean
-  public OpenAPI openAPI() {
-    SecurityScheme securityScheme = new SecurityScheme().type(Type.HTTP)
-        .scheme("bearer")
-        .bearerFormat("JWT")
-        .in(In.HEADER)
-        .name("Authorization");
-
-    SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
-
-    return new OpenAPI().components(
-        new Components().addSecuritySchemes("bearerAuth", securityScheme)).security(Arrays.asList(securityRequirement));
-
-  }
-
+    
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme().type(Type.HTTP)
+                                                            .scheme("bearer")
+                                                            .bearerFormat("JWT")
+                                                            .in(In.HEADER)
+                                                            .name("Authorization");
+        
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+        
+        return new OpenAPI().components(
+                                new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                            .security(Collections.singletonList(securityRequirement));
+        
+    }
+    
+    /**
+     * Swagger를 통한 API Docs 작성시 기본 기능으로 지원되지 않는 부분을 직접 Custom 하는 Bean.
+     *
+     * 현재 구현된 Custom 기능 목록:
+     * 1. FailResponseStatus 목록을 지정하기만 해도 에러 응답 예시를 자동으로 생성.
+     *
+     * @return OperationCustomizer 구현체
+     */
+    @Bean
+    public OperationCustomizer customOperation() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            ApiErrorResponses errorResponses = handlerMethod.getMethodAnnotation(ApiErrorResponses.class);
+            
+            if (errorResponses != null) {
+                ApiResponses responses = operation.getResponses();
+                
+                // HTTP Status 별 Fail Status 그룹화
+                Map<HttpStatus, List<FailResponseStatus>> failStatusesByHttpStatus =
+                    Arrays.stream(errorResponses.errors())
+                          .collect(Collectors.groupingBy(FailResponseStatus::getHttpStatusCode));
+                
+                // HTTP Status 별 응답 예시 생성
+                failStatusesByHttpStatus.forEach((httpStatus, failStatusList) -> {
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+                    
+                    failStatusList.forEach(failStatus -> {
+                        mediaType.addExamples(failStatus.getStatusCode(),
+                                              getResponseExample(failStatus));
+                    });
+                    
+                    content.addMediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+                                         mediaType);
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(String.valueOf(httpStatus.value()),
+                                             apiResponse);
+                });
+                
+            }
+            return operation;
+        };
+    }
+    
+    /**
+     * 각 FailResponseStatus 별 Example 객체를 생성한다.
+     *
+     * @param status
+     * @return Example 객체
+     */
+    private Example getResponseExample(FailResponseStatus status) {
+        FailResponseDto response = FailResponseDto.builder()
+                                                  .statusCode(status.getStatusCode())
+                                                  .message(status.getMessage())
+                                                  .build();
+        
+        return new Example()
+            .value(response)
+            .summary(status.getStatusCode() + " (" + status.getStatusName() + ")")
+            .description(status.getMessage());
+    }
+    
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberController.java
@@ -4,9 +4,12 @@ import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateTokenResult;
 import com.LetMeDoWith.LetMeDoWith.application.auth.service.CreateTokenService;
 import com.LetMeDoWith.LetMeDoWith.application.member.dto.CreateSignupCompletedMemberCommand;
 import com.LetMeDoWith.LetMeDoWith.application.member.service.MemberService;
+import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponses;
+import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiSuccessResponse;
+import com.LetMeDoWith.LetMeDoWith.common.dto.ResponseDto;
+import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
 import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
 import com.LetMeDoWith.LetMeDoWith.common.exception.status.SuccessResponseStatus;
-import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
 import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
 import com.LetMeDoWith.LetMeDoWith.domain.member.model.Member;
 import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenResDto;
@@ -39,9 +42,16 @@ public class MemberController {
      * @param signupCompleteReqDto 회원가입을 완료하려는 멤버의 추가 정보 및 약관 동의 정보
      * @return 로그인 결과. 액세스 트큰과, refresh 토큰
      */
-    @Operation(summary = "회원가입", description = "소셜 로그인 후 회원가입을 완료합니다.")
+    @Operation(summary = "회원가입", description = "회원가입을 완료하고 로그인합니다.")
+    @ApiSuccessResponse(description = "회원가입 완료, 회원 정보를 업데이트하고 로그인을 완료함 (토큰 발급).")
+    @ApiErrorResponses(errors = {
+        FailResponseStatus.MEMBER_NOT_EXIST,
+        FailResponseStatus.DUPLICATE_NICKNAME,
+        FailResponseStatus.TOKEN_EXPIRED_BY_ADMIN
+    })
     @PutMapping("")
-    public ResponseEntity completeSignup(@RequestBody SignupCompleteReqDto signupCompleteReqDto) {
+    public ResponseEntity<ResponseDto<CreateTokenResDto>> completeSignup(
+        @RequestBody SignupCompleteReqDto signupCompleteReqDto) {
         CreateSignupCompletedMemberCommand command =
             CreateSignupCompletedMemberCommand.builder()
                                               .nickname(signupCompleteReqDto.nickname())
@@ -58,8 +68,9 @@ public class MemberController {
         Member signupCompletedMember = memberService.createSignupCompletedMember(command);
         CreateTokenResult createTokenResult = createTokenService.createToken(signupCompletedMember);
         
-        return ResponseUtil.createSuccessResponse(SuccessResponseStatus.OK, CreateTokenResDto.fromCreateTokenResult(
-            createTokenResult));
+        return ResponseUtil.createSuccessResponse(SuccessResponseStatus.OK,
+                                                  CreateTokenResDto.fromCreateTokenResult(
+                                                      createTokenResult));
     }
     
     /**
@@ -91,8 +102,10 @@ public class MemberController {
      * @return 닉네임의 검증 결과
      */
     @Operation(summary = "닉네임 중복 여부 검증", description = "닉네임 중복 여부를 검증합니다.")
+    @ApiSuccessResponse(description = "사용 가능한 닉네임")
+    @ApiErrorResponses(errors = {FailResponseStatus.DUPLICATE_NICKNAME})
     @PostMapping("/nickname")
-    public ResponseEntity checkNickname(@RequestBody String nickname) {
+    public ResponseEntity<ResponseDto<String>> checkNickname(@RequestBody String nickname) {
         if (memberService.isExistingNickname(nickname)) {
             throw new RestApiException(FailResponseStatus.DUPLICATE_NICKNAME);
         } else {
@@ -107,8 +120,10 @@ public class MemberController {
      * @return 탈퇴 성공 여부
      */
     @Operation(summary = "탈퇴", description = "해당 회원을 탈퇴 처리 합니다.")
+    @ApiSuccessResponse(description = "회원 탈퇴 완료")
+    @ApiErrorResponses(errors = {FailResponseStatus.MEMBER_NOT_EXIST})
     @DeleteMapping("/{memberId}")
-    public ResponseEntity withdrawMember(@PathVariable Long memberId) {
+    public <T> ResponseEntity<ResponseDto<T>> withdrawMember(@PathVariable Long memberId) {
         memberService.withdrawMember(memberId);
         
         return ResponseUtil.createSuccessResponse(SuccessResponseStatus.OK);

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberSettingController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberSettingController.java
@@ -2,6 +2,7 @@ package com.LetMeDoWith.LetMeDoWith.presentation.member.controller;
 
 import com.LetMeDoWith.LetMeDoWith.application.member.dto.UpdateMemberAlarmSettingCommand;
 import com.LetMeDoWith.LetMeDoWith.application.member.service.MemberSettingService;
+import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponse;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponses;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiSuccessResponse;
 import com.LetMeDoWith.LetMeDoWith.common.dto.ResponseDto;
@@ -33,7 +34,9 @@ public class MemberSettingController {
      */
     @Operation(summary = "알림 수신 상태 변경", description = "회원의 알림 수신 상태를 변경합니다.")
     @ApiSuccessResponse(description = "회원 알림 수신상태 변경 성공")
-    @ApiErrorResponses(errors = {FailResponseStatus.MEMBER_NOT_EXIST})
+    @ApiErrorResponses({
+        @ApiErrorResponse(status = FailResponseStatus.MEMBER_NOT_EXIST)
+    })
     @PutMapping("/alarm")
     public <T> ResponseEntity<ResponseDto<T>> updateAlarm(
         @RequestBody UpdateMemberAlarmSettingReq req) {

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberSettingController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberSettingController.java
@@ -2,6 +2,10 @@ package com.LetMeDoWith.LetMeDoWith.presentation.member.controller;
 
 import com.LetMeDoWith.LetMeDoWith.application.member.dto.UpdateMemberAlarmSettingCommand;
 import com.LetMeDoWith.LetMeDoWith.application.member.service.MemberSettingService;
+import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponses;
+import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiSuccessResponse;
+import com.LetMeDoWith.LetMeDoWith.common.dto.ResponseDto;
+import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
 import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.UpdateMemberAlarmSettingReq;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,8 +32,11 @@ public class MemberSettingController {
      * @return 성공 응답
      */
     @Operation(summary = "알림 수신 상태 변경", description = "회원의 알림 수신 상태를 변경합니다.")
+    @ApiSuccessResponse(description = "회원 알림 수신상태 변경 성공")
+    @ApiErrorResponses(errors = {FailResponseStatus.MEMBER_NOT_EXIST})
     @PutMapping("/alarm")
-    public ResponseEntity updateAlarm(@RequestBody UpdateMemberAlarmSettingReq req) {
+    public <T> ResponseEntity<ResponseDto<T>> updateAlarm(
+        @RequestBody UpdateMemberAlarmSettingReq req) {
         memberSettingService.updateAlarmSetting(UpdateMemberAlarmSettingCommand.fromReq(req));
         
         return ResponseUtil.createSuccessResponse();

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/CreateMemberTermAgreeReqDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/CreateMemberTermAgreeReqDto.java
@@ -1,10 +1,18 @@
 package com.LetMeDoWith.LetMeDoWith.presentation.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record CreateMemberTermAgreeReqDto(Boolean termsOfAgree,
-										  Boolean privacy,
-										  Boolean advertisement) {
+@Schema(description = "회원가입 시 약관 항목 별 동의 여부")
+public record CreateMemberTermAgreeReqDto(
+    @Schema(description = "이용약관 동의 여부 (항상 true)", defaultValue = "true")
+    Boolean termsOfAgree,
+    
+    @Schema(description = "개인정보 활용 동의 여부 (항상 true)", defaultValue = "true")
+    Boolean privacy,
+    
+    @Schema(description = "광고성 정보 동의 여부")
+    Boolean advertisement) {
     
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/SignupCompleteReqDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/SignupCompleteReqDto.java
@@ -1,15 +1,23 @@
 package com.LetMeDoWith.LetMeDoWith.presentation.member.dto;
 
 import com.LetMeDoWith.LetMeDoWith.common.enums.member.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
-
 import lombok.Builder;
 
 @Builder
+@Schema(description = "회원가입 완료 요청시 필요한 추가 개인정보")
 public record SignupCompleteReqDto(
+    @Schema(description = "회원의 닉네임")
     String nickname,
+    
+    @Schema(description = "회원의 생년월일")
     LocalDate dateOfBirth,
+    
+    @Schema(description = "회원의 성별", implementation = Gender.class)
     Gender gender,
+    
+    @Schema(description = "회원의 약관 항목별 동의 여부", implementation = CreateMemberTermAgreeReqDto.class)
     CreateMemberTermAgreeReqDto agreements) {
     
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/UpdateMemberAlarmSettingReq.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/UpdateMemberAlarmSettingReq.java
@@ -1,9 +1,16 @@
 package com.LetMeDoWith.LetMeDoWith.presentation.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 알람 수신 상태 변경 요청")
 public record UpdateMemberAlarmSettingReq(
+    @Schema(description = "기본 알람 수신 여부")
     boolean baseAlarmYn,
+    @Schema(description = "투두 알림봇 알람 수신 여부")
     boolean todoBotYn,
+    @Schema(description = "잔소리 (피드백) 알람 수신 여부")
     boolean feedbackYn,
+    @Schema(description = "마케팅, 광고성 알람 수신 여부")
     boolean marketingYn
 ) {
 

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/task/controller/TaskCategoryController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/task/controller/TaskCategoryController.java
@@ -1,6 +1,8 @@
 package com.LetMeDoWith.LetMeDoWith.presentation.task.controller;
 
 import com.LetMeDoWith.LetMeDoWith.application.task.service.TaskCategoryService;
+import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiSuccessResponse;
+import com.LetMeDoWith.LetMeDoWith.common.dto.ResponseDto;
 import com.LetMeDoWith.LetMeDoWith.common.util.AuthUtil;
 import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
 import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.GetAllTaskCategoryRes;
@@ -22,10 +24,11 @@ public class TaskCategoryController {
     
     @Autowired
     private TaskCategoryService taskCategoryService;
-
-    @Operation(summary = "테스크 카테고리 조회", description = "테스트 카테고리를 조회합니다.")
+    
+    @Operation(summary = "태스크 카테고리 조회", description = "모든 태스크 카테고리를 조회합니다. (공통 + 유저 생성)")
+    @ApiSuccessResponse(description = "카테고리 조회 성공")
     @GetMapping("")
-    public ResponseEntity getAllTaskCategories() {
+    public ResponseEntity<ResponseDto<List<GetAllTaskCategoryRes>>> getAllTaskCategories() {
         
         Long memberId = AuthUtil.getMemberId();
         

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/task/dto/GetAllTaskCategoryRes.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/task/dto/GetAllTaskCategoryRes.java
@@ -2,8 +2,16 @@ package com.LetMeDoWith.LetMeDoWith.presentation.task.dto;
 
 import com.LetMeDoWith.LetMeDoWith.domain.task.TaskCategory;
 import com.LetMeDoWith.LetMeDoWith.domain.task.TaskCategory.TaskCategoryCreationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import java.util.List;
 
+@Schema(description = "Task 카테고리 조회 결과")
+@SchemaProperty(name = "id", schema = @Schema(description = "조회한 Task Category의 id"))
+@SchemaProperty(name = "title", schema = @Schema(description = "Task Category의 이름"))
+@SchemaProperty(name = "creationType", schema = @Schema(description = "Task Category의 타입 (공통 / 유저 개인)", implementation = TaskCategoryCreationType.class))
+@SchemaProperty(name = "emoji", schema = @Schema(description = "Task Category 표시 이모티콘"))
+@SchemaProperty(name = "categoryHolderId", schema = @Schema(description = "유저 생성 Category 인 경우 생성한 member의 id"))
 public record GetAllTaskCategoryRes(
     Long id,
     String title,
@@ -11,6 +19,8 @@ public record GetAllTaskCategoryRes(
     String emoji,
     Long categoryHolderId
 ) {
+    
+    // todo: 단일 객체 형태 말고 List 형태로 수정할 것.
     
     public static GetAllTaskCategoryRes from(TaskCategory taskCategory) {
         return new GetAllTaskCategoryRes(taskCategory.getId(),

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/task/DowithTaskIntegrationTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/task/DowithTaskIntegrationTest.java
@@ -1,153 +1,153 @@
-package com.LetMeDoWith.LetMeDoWith.integration.task;
-
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import com.LetMeDoWith.LetMeDoWith.application.auth.provider.AccessTokenProvider;
-import com.LetMeDoWith.LetMeDoWith.common.enums.member.Gender;
-import com.LetMeDoWith.LetMeDoWith.common.enums.member.MemberStatus;
-import com.LetMeDoWith.LetMeDoWith.common.enums.member.MemberType;
-import com.LetMeDoWith.LetMeDoWith.common.enums.member.TaskCompleteLevel;
-import com.LetMeDoWith.LetMeDoWith.common.util.DateTimeUtil;
-import com.LetMeDoWith.LetMeDoWith.domain.auth.model.AccessToken;
-import com.LetMeDoWith.LetMeDoWith.domain.member.model.Member;
-import com.LetMeDoWith.LetMeDoWith.domain.task.enums.DowithTaskStatus;
-import com.LetMeDoWith.LetMeDoWith.infrastructure.member.jpaRepository.MemberJpaRepository;
-import com.LetMeDoWith.LetMeDoWith.infrastructure.task.jpaRepository.DowithTaskJpaRepository;
-import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.CreateDowithTaskReqDto;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import lombok.extern.slf4j.Slf4j;
-import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.util.LinkedMultiValueMap;
-
-@Slf4j
-@SpringBootTest
-@ActiveProfiles("local")
-@AutoConfigureMockMvc
-public class DowithTaskIntegrationTest {
-
-  static final String BASE_URL = "/api/v1/task/dowith";
-  static final String CREATE_DOWITH_TASK = "";
-
-  @Autowired
-  ObjectMapper objectMapper;
-  @Autowired
-  MockMvc mockMvc;
-  @Autowired
-  MemberJpaRepository memberJpaRepository;
-  @Autowired
-  AccessTokenProvider accessTokenProvider;
-  @Autowired
-  DowithTaskJpaRepository dowithTaskJpaRepository;
-
-
-  private Member member;
-  private AccessToken memberAccessToken;
-
-  @BeforeEach
-  void beforeEach() {
-    memberJpaRepository.deleteAll();
-    dowithTaskJpaRepository.deleteAll();
-
-    member = memberJpaRepository.save(Member.builder()
-        .status(MemberStatus.NORMAL)
-        .taskCompleteLevel(TaskCompleteLevel.AVERAGE)
-        .nickname("test")
-        .selfDescription("test description")
-        .gender(Gender.MALE)
-        .dateOfBirth(LocalDate.of(1995, 11, 4))
-        .type(MemberType.USER)
-        .build());
-    memberAccessToken = accessTokenProvider.createAccessToken(member.getId());
-  }
-
-  private ResultActions requestCreateDowithTask(AccessToken accessToken, CreateDowithTaskReqDto requestBody) throws Exception {
-    LinkedMultiValueMap<String, String> headerMap = new LinkedMultiValueMap<>();
-    headerMap.add("AUTHORIZATION", "Bearer" + accessToken.getToken());
-
-    return mockMvc.perform(MockMvcRequestBuilders.post(BASE_URL + CREATE_DOWITH_TASK)
-        .headers(new HttpHeaders(headerMap))
-        .contentType(MediaType.APPLICATION_JSON)
-        .accept(MediaType.APPLICATION_JSON)
-        .characterEncoding(StandardCharsets.UTF_8)
-        .content(objectMapper.writeValueAsString(requestBody)))
-        .andDo(System.out::println);
-  }
-
-  @Test
-  @DisplayName("[SUCCESS] Dowith Task 등록")
-  void createDowithTask() throws Exception {
-    // given
-    LocalDateTime startDateTime = LocalDateTime.now().plusDays(1);
-    CreateDowithTaskReqDto requestBody = new CreateDowithTaskReqDto("테스트", 1L, startDateTime, Boolean.FALSE,
-        null);
-
-    // when
-    ResultActions resultActions = requestCreateDowithTask(memberAccessToken, requestBody);
-
-    // then
-    resultActions.andExpect(status().is2xxSuccessful())
-        .andExpect(jsonPath("$.data.dowithTaskDtos[0].id").exists())
-        .andExpect(jsonPath("$.data.dowithTaskDtos[0].taskCategoryId").value(requestBody.taskCategoryId()))
-        .andExpect(jsonPath("$.data.dowithTaskDtos[0].title").value(requestBody.title()))
-        .andExpect(jsonPath("$.data.dowithTaskDtos[0].status").value(DowithTaskStatus.WAIT.getCode()))
-        .andExpect(jsonPath("$.data.dowithTaskDtos[0].date").value(DateTimeUtil.toFormatString(startDateTime.toLocalDate())))
-        .andExpect(jsonPath("$.data.dowithTaskDtos[0].startTime").value(DateTimeUtil.toFormatString(startDateTime.toLocalTime())))
-        .andExpect(jsonPath("$.data.dowithTaskDtos[0].isRoutine").value(Boolean.FALSE))
-        .andDo(System.out::println);
-
-  }
-
-  @Test
-  @DisplayName("[SUCCESS] Dowith Task 등록")
-  void createDowithTaskWithRoutine() throws Exception {
-    // given
-    LocalDateTime startDateTime = LocalDateTime.now().plusDays(1);
-    LocalDate routineDate1 = startDateTime.plusMonths(3).toLocalDate();
-    LocalDate routineDate2 = startDateTime.plusDays(2).toLocalDate();
-    ArrayList<LocalDate> targetDates = new ArrayList<>();
-    targetDates.add(startDateTime.toLocalDate());
-    targetDates.add(routineDate1);
-    targetDates.add(routineDate2);
-    Collections.sort(targetDates);
-    CreateDowithTaskReqDto requestBody = new CreateDowithTaskReqDto("테스트", 1L, startDateTime, Boolean.TRUE,
-        List.of(routineDate1, routineDate2));
-
-    // when
-    ResultActions resultActions = requestCreateDowithTask(memberAccessToken, requestBody);
-
-    // then
-    for (int i = 0; i < targetDates.size(); i++) {
-      resultActions.andExpect(status().is2xxSuccessful())
-          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].id").exists())
-          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].taskCategoryId").value(requestBody.taskCategoryId()))
-          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].title").value(requestBody.title()))
-          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].status").value(DowithTaskStatus.WAIT.getCode()))
-          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].date").value(DateTimeUtil.toFormatString(targetDates.get(i))))
-          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].startTime").value(DateTimeUtil.toFormatString(startDateTime.toLocalTime())))
-          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].isRoutine").value(Boolean.TRUE))
-          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].routineDates").value(new IsEqual<>(List.of(DateTimeUtil.toFormatString(targetDates.get(0)), DateTimeUtil.toFormatString(targetDates.get(1)), DateTimeUtil.toFormatString(targetDates.get(2)))), List.class))
-          .andDo(System.out::println);
-    }
-
-    // TODO - 등록 실패 케이스 - 화면설계서 구체화되면 작성
-  }
-}
+//package com.LetMeDoWith.LetMeDoWith.integration.task;
+//
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//
+//import com.LetMeDoWith.LetMeDoWith.application.auth.provider.AccessTokenProvider;
+//import com.LetMeDoWith.LetMeDoWith.common.enums.member.Gender;
+//import com.LetMeDoWith.LetMeDoWith.common.enums.member.MemberStatus;
+//import com.LetMeDoWith.LetMeDoWith.common.enums.member.MemberType;
+//import com.LetMeDoWith.LetMeDoWith.common.enums.member.TaskCompleteLevel;
+//import com.LetMeDoWith.LetMeDoWith.common.util.DateTimeUtil;
+//import com.LetMeDoWith.LetMeDoWith.domain.auth.model.AccessToken;
+//import com.LetMeDoWith.LetMeDoWith.domain.member.model.Member;
+//import com.LetMeDoWith.LetMeDoWith.domain.task.enums.DowithTaskStatus;
+//import com.LetMeDoWith.LetMeDoWith.infrastructure.member.jpaRepository.MemberJpaRepository;
+//import com.LetMeDoWith.LetMeDoWith.infrastructure.task.jpaRepository.DowithTaskJpaRepository;
+//import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.CreateDowithTaskReqDto;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import java.nio.charset.StandardCharsets;
+//import java.time.LocalDate;
+//import java.time.LocalDateTime;
+//import java.util.ArrayList;
+//import java.util.Collections;
+//import java.util.List;
+//import lombok.extern.slf4j.Slf4j;
+//import org.hamcrest.core.IsEqual;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.http.HttpHeaders;
+//import org.springframework.http.MediaType;
+//import org.springframework.test.context.ActiveProfiles;
+//import org.springframework.test.web.servlet.MockMvc;
+//import org.springframework.test.web.servlet.ResultActions;
+//import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+//import org.springframework.util.LinkedMultiValueMap;
+//
+//@Slf4j
+//@SpringBootTest
+//@ActiveProfiles("local")
+//@AutoConfigureMockMvc
+//public class DowithTaskIntegrationTest {
+//
+//  static final String BASE_URL = "/api/v1/task/dowith";
+//  static final String CREATE_DOWITH_TASK = "";
+//
+//  @Autowired
+//  ObjectMapper objectMapper;
+//  @Autowired
+//  MockMvc mockMvc;
+//  @Autowired
+//  MemberJpaRepository memberJpaRepository;
+//  @Autowired
+//  AccessTokenProvider accessTokenProvider;
+//  @Autowired
+//  DowithTaskJpaRepository dowithTaskJpaRepository;
+//
+//
+//  private Member member;
+//  private AccessToken memberAccessToken;
+//
+//  @BeforeEach
+//  void beforeEach() {
+//    memberJpaRepository.deleteAll();
+//    dowithTaskJpaRepository.deleteAll();
+//
+//    member = memberJpaRepository.save(Member.builder()
+//        .status(MemberStatus.NORMAL)
+//        .taskCompleteLevel(TaskCompleteLevel.AVERAGE)
+//        .nickname("test")
+//        .selfDescription("test description")
+//        .gender(Gender.MALE)
+//        .dateOfBirth(LocalDate.of(1995, 11, 4))
+//        .type(MemberType.USER)
+//        .build());
+//    memberAccessToken = accessTokenProvider.createAccessToken(member.getId());
+//  }
+//
+//  private ResultActions requestCreateDowithTask(AccessToken accessToken, CreateDowithTaskReqDto requestBody) throws Exception {
+//    LinkedMultiValueMap<String, String> headerMap = new LinkedMultiValueMap<>();
+//    headerMap.add("AUTHORIZATION", "Bearer" + accessToken.getToken());
+//
+//    return mockMvc.perform(MockMvcRequestBuilders.post(BASE_URL + CREATE_DOWITH_TASK)
+//        .headers(new HttpHeaders(headerMap))
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .accept(MediaType.APPLICATION_JSON)
+//        .characterEncoding(StandardCharsets.UTF_8)
+//        .content(objectMapper.writeValueAsString(requestBody)))
+//        .andDo(System.out::println);
+//  }
+//
+//  @Test
+//  @DisplayName("[SUCCESS] Dowith Task 등록")
+//  void createDowithTask() throws Exception {
+//    // given
+//    LocalDateTime startDateTime = LocalDateTime.now().plusDays(1);
+//    CreateDowithTaskReqDto requestBody = new CreateDowithTaskReqDto("테스트", 1L, startDateTime, Boolean.FALSE,
+//        null);
+//
+//    // when
+//    ResultActions resultActions = requestCreateDowithTask(memberAccessToken, requestBody);
+//
+//    // then
+//    resultActions.andExpect(status().is2xxSuccessful())
+//        .andExpect(jsonPath("$.data.dowithTaskDtos[0].id").exists())
+//        .andExpect(jsonPath("$.data.dowithTaskDtos[0].taskCategoryId").value(requestBody.taskCategoryId()))
+//        .andExpect(jsonPath("$.data.dowithTaskDtos[0].title").value(requestBody.title()))
+//        .andExpect(jsonPath("$.data.dowithTaskDtos[0].status").value(DowithTaskStatus.WAIT.getCode()))
+//        .andExpect(jsonPath("$.data.dowithTaskDtos[0].date").value(DateTimeUtil.toFormatString(startDateTime.toLocalDate())))
+//        .andExpect(jsonPath("$.data.dowithTaskDtos[0].startTime").value(DateTimeUtil.toFormatString(startDateTime.toLocalTime())))
+//        .andExpect(jsonPath("$.data.dowithTaskDtos[0].isRoutine").value(Boolean.FALSE))
+//        .andDo(System.out::println);
+//
+//  }
+//
+//  @Test
+//  @DisplayName("[SUCCESS] Dowith Task 등록")
+//  void createDowithTaskWithRoutine() throws Exception {
+//    // given
+//    LocalDateTime startDateTime = LocalDateTime.now().plusDays(1);
+//    LocalDate routineDate1 = startDateTime.plusMonths(3).toLocalDate();
+//    LocalDate routineDate2 = startDateTime.plusDays(2).toLocalDate();
+//    ArrayList<LocalDate> targetDates = new ArrayList<>();
+//    targetDates.add(startDateTime.toLocalDate());
+//    targetDates.add(routineDate1);
+//    targetDates.add(routineDate2);
+//    Collections.sort(targetDates);
+//    CreateDowithTaskReqDto requestBody = new CreateDowithTaskReqDto("테스트", 1L, startDateTime, Boolean.TRUE,
+//        List.of(routineDate1, routineDate2));
+//
+//    // when
+//    ResultActions resultActions = requestCreateDowithTask(memberAccessToken, requestBody);
+//
+//    // then
+//    for (int i = 0; i < targetDates.size(); i++) {
+//      resultActions.andExpect(status().is2xxSuccessful())
+//          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].id").exists())
+//          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].taskCategoryId").value(requestBody.taskCategoryId()))
+//          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].title").value(requestBody.title()))
+//          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].status").value(DowithTaskStatus.WAIT.getCode()))
+//          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].date").value(DateTimeUtil.toFormatString(targetDates.get(i))))
+//          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].startTime").value(DateTimeUtil.toFormatString(startDateTime.toLocalTime())))
+//          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].isRoutine").value(Boolean.TRUE))
+//          .andExpect(jsonPath("$.data.dowithTaskDtos[" + i + "].routineDates").value(new IsEqual<>(List.of(DateTimeUtil.toFormatString(targetDates.get(0)), DateTimeUtil.toFormatString(targetDates.get(1)), DateTimeUtil.toFormatString(targetDates.get(2)))), List.class))
+//          .andDo(System.out::println);
+//    }
+//
+//    // TODO - 등록 실패 케이스 - 화면설계서 구체화되면 작성
+//  }
+//}


### PR DESCRIPTION
## PR 체크리스트
Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요 

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?
- [ ] 모든 Test 코드를 실행하여 PASS했나요?
- [x] 포스트맨 API 명세를 작성하였나요?


## PR 타입
PR의 타입을 체크해주세요

<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 픽스 - 이슈 링크 : 
- [x] 신규 기능 개발
- [ ] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [ ] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타


## 코드 변경 이유

- 이슈 링크 : N/A



## 변경된 사항

- Swagger 명세 작성
- Swagger 명세 작성시 에러 및 성공 응답 스키마를 자동 생성하는 Customizer 구현

## 테스트 방법

-
-

## 리뷰어 집중 사항

- Customizer 및 `@ApiSuccessResponse`, `@ApiErrorResponses` 애노테이션
- 


## 기타 전달 사항

- 같은 statusCode를 갖는 Example을 여러개 선언 불가
- 에러 응답이 여러개일 경우 일일히 나열하기 힘듬
- Response 객체가 제네릭을 받음

등의 어려움이 있었는데 이를 Customizer 구현과 커스텀 어노테이션으로 어느정도 자동화 하였습니다.

실제 사용시에, 아래와 같이 명세를 선언하면 됩니다.

<img width="833" alt="image" src="https://github.com/user-attachments/assets/0f58acd9-aa93-473b-919a-3c4c9646c733" />

- `@ApiSuccessResponse`: 설명만 입력하면 됨. 자동으로 200 응답으로 매핑하고, 응답 객체를 정확하게 표현함. 다만 메서드의 리턴 타입을 `ResponseEntity`만 적으면 안되고 정확한 제네릭 타입을 적어줘야 Swagger에서 정확한 응답 객체의 스키마를 보여줍니다.
- `@ApiErrorResponses`: 해당 엔드포인트의 로직 실행 중 발생 가능한 모든 실패 응답 사유를 나열하기만 하면 됨.


[결과 화면]
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/a60f7fe9-eec8-4f72-976f-2c492ac3f389" />


