### PR TITLE
feat : 캐시 공통 (CachePolicy, CacheName, CacheHelper)

### DIFF
--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
@@ -1,13 +1,15 @@
 package com.LetMeDoWith.LetMeDoWith.common.cache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -57,6 +59,26 @@ public class CacheHelper {
         }
     }
 
+    public <T> List<T> getByRange(String cacheName, String key, long start, long end, Class<T> elementType) {
+        CachePolicy cachePolicy = CachePolicy.fromCacheName(cacheName);
+        String redisKey = this.buildRedisKey(cacheName, key);
+
+        if (cachePolicy.redisValueType().equals(RedisValueType.LIST)) {
+            List<Object> rawList = redisTemplate.opsForList().range(redisKey, start, end);
+            if (rawList == null) {
+                return Collections.emptyList();
+            }
+            List<T> resultList = new ArrayList<>();
+            for (Object item : rawList) {
+                T element = objectMapper.convertValue(item, elementType);
+                resultList.add(element);
+            }
+            return resultList;
+        } else {
+            throw new IllegalArgumentException("CachePolicy redisValueType is not LIST for cache name: " + cacheName);
+        }
+    }
+
     public void put(String cacheName, String key, Object value) {
 
         CachePolicy cachePolicy = CachePolicy.fromCacheName(cacheName);
@@ -78,7 +100,50 @@ public class CacheHelper {
         }
     }
 
+    public void push(String cacheName, String key, Object element) {
+        CachePolicy cachePolicy = CachePolicy.fromCacheName(cacheName);
+        String redisKey = this.buildRedisKey(cacheName, key);
+
+        if (cachePolicy.redisValueType().equals(RedisValueType.LIST)) {
+            redisTemplate.opsForList().rightPush(redisKey, element);
+            if (cachePolicy.ttl() != null) {
+                redisTemplate.expire(redisKey, cachePolicy.ttl());
+            }
+        } else {
+            throw new IllegalArgumentException("CachePolicy redisValueType is not LIST for cache name: " + cacheName);
+        }
+    }
+
+    public void remove(String cacheName, String key) {
+        CachePolicy cachePolicy = CachePolicy.fromCacheName(cacheName);
+
+        if (cachePolicy.redisValueType().equals(RedisValueType.HASH)
+                || cachePolicy.redisValueType().equals(RedisValueType.LIST)) {
+            String redisKey = this.buildRedisKey(cacheName, key);
+            redisTemplate.delete(redisKey);
+        } else {
+            Cache cache = cacheManager.getCache(cacheName);
+            assert cache != null;
+            cache.evict(key);
+        }
+    }
+
+    public <T> void remove(String cacheName, String key, T element) {
+        CachePolicy cachePolicy = CachePolicy.fromCacheName(cacheName);
+
+        if (!cachePolicy.redisValueType().equals(RedisValueType.LIST)) {
+            throw new IllegalArgumentException("CachePolicy redisValueType is not LIST for cache name: " + cacheName);
+        }
+
+        String cacheKey = this.buildRedisKey(cacheName, key);
+
+        redisTemplate.opsForList().remove(cacheKey, 0, element);
+    }
+
     private String buildRedisKey(String cacheName, String key) {
+        if (key == null || key.isEmpty()) {
+            return cacheName;
+        }
         return cacheName + "::" + key;
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
@@ -13,7 +13,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class CacheHelper {
 
-    private final RedisTemplate<Object, Object> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
     private final CacheManager cacheManager;
 
     private final ObjectMapper objectMapper;
@@ -48,12 +48,14 @@ public class CacheHelper {
                 return null;
             }
 
-            if (fieldType.isInstance(value)) {
-                return fieldType.cast(value);
+            if (!fieldType.isInstance(value)) {
+                throw new IllegalArgumentException("Cached value type mismatch. Expected: "
+                        + value.getClass().getName() + ", but input parameter filedType: " + fieldType.getName());
             }
-            return objectMapper.convertValue(value, fieldType);
+            return fieldType.cast(value);
+            //            return objectMapper.convertValue(value, fieldType);
         } else {
-            throw new IllegalArgumentException("Cache type is not HASH for cache name: " + cacheName);
+            throw new IllegalArgumentException("CachePolicy redisValueType is not HASH for cache name: " + cacheName);
         }
     }
 

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
@@ -1,12 +1,13 @@
 package com.LetMeDoWith.LetMeDoWith.common.cache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -53,7 +54,6 @@ public class CacheHelper {
                         + value.getClass().getName() + ", but input parameter filedType: " + fieldType.getName());
             }
             return fieldType.cast(value);
-            //            return objectMapper.convertValue(value, fieldType);
         } else {
             throw new IllegalArgumentException("CachePolicy redisValueType is not HASH for cache name: " + cacheName);
         }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
@@ -1,13 +1,12 @@
 package com.LetMeDoWith.LetMeDoWith.common.cache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
@@ -1,12 +1,13 @@
 package com.LetMeDoWith.LetMeDoWith.common.cache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -30,9 +31,7 @@ public class CacheHelper {
             return objectMapper.convertValue(entries, type);
         } else {
             Cache cache = cacheManager.getCache(cacheName);
-            if (cache == null) {
-                throw new IllegalStateException("No Cache found for cache name: " + cacheName);
-            }
+            assert cache != null;
             return cache.get(key, type);
         }
     }
@@ -74,7 +73,7 @@ public class CacheHelper {
             redisTemplate.expire(redisKey, cachePolicy.ttl());
         } else {
             Cache cache = cacheManager.getCache(cacheName);
-            if (cache == null) throw new IllegalStateException("No Cache found for cache name: " + cacheName);
+            assert cache != null;
             cache.put(key, value);
         }
     }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
@@ -1,0 +1,89 @@
+package com.LetMeDoWith.LetMeDoWith.common.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CacheHelper {
+
+    private final RedisTemplate<Object, Object> redisTemplate;
+    private final CacheManager cacheManager;
+
+    private final ObjectMapper objectMapper;
+
+    // 필요사항
+    //// 캐시 name 기반으로 캐시 넣기
+    //// 캐시 name 별로 Redis에 캐시하고 있는 자료구조가 다름
+    //////// ex. Dowith 같은 경우, Hash 구조로 되어있음
+    //// Hash 구조에서 key 기반으로 value 가져오기
+    //// Hash 구조에서 key 기반으로 value 삭제하기
+    //// 과정에서
+
+    public <T> T get(String cacheName, String key, Class<T> type) {
+
+        CachePolicy cachePolicy = CachePolicy.fromCacheName(cacheName);
+
+        if (cachePolicy.redisValueType().equals(RedisValueType.HASH)) {
+            Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
+            if (entries.isEmpty()) {
+                return null;
+            }
+            return objectMapper.convertValue(entries, type);
+        } else {
+            Cache cache = cacheManager.getCache(cacheName);
+            if (cache == null) {
+                return null;
+            }
+            return cache.get(key, type);
+        }
+    }
+
+    public <T> T get(String cacheName, String key, String field, Class<T> type) {
+
+        CachePolicy cachePolicy = CachePolicy.fromCacheName(cacheName);
+
+        if (cachePolicy.redisValueType().equals(RedisValueType.HASH)) {
+            Object value = redisTemplate.opsForHash().get(key, field);
+            if (value == null) {
+                return null;
+            }
+
+            if (type.isInstance(value)) {
+                return type.cast(value);
+            }
+            return objectMapper.convertValue(value, type);
+        } else {
+            throw new IllegalArgumentException("Cache type is not HASH for cache name: " + cacheName);
+        }
+    }
+
+    public void put(String cacheName, String key, Object value) {
+
+        CachePolicy cachePolicy = CachePolicy.fromCacheName(cacheName);
+        String redisKey = this.buildRedisKey(cacheName, key);
+
+        if (cachePolicy.redisValueType().equals(RedisValueType.HASH)) {
+            Map<?, ?> mapValue;
+            if (value instanceof Map<?, ?> rawMap) {
+                mapValue = rawMap;
+            } else {
+                mapValue = objectMapper.convertValue(value, Map.class);
+            }
+            redisTemplate.opsForHash().putAll(redisKey, mapValue);
+        } else {
+            Cache cache = cacheManager.getCache(cacheName);
+            if (cache == null) throw new IllegalArgumentException("No Cache found for cache name: " + cacheName);
+            cache.put(key, value);
+        }
+    }
+
+    private String buildRedisKey(String cacheName, String key) {
+        return cacheName + "::" + key;
+    }
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
@@ -1,12 +1,13 @@
 package com.LetMeDoWith.LetMeDoWith.common.cache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -16,14 +17,6 @@ public class CacheHelper {
     private final CacheManager cacheManager;
 
     private final ObjectMapper objectMapper;
-
-    // 필요사항
-    //// 캐시 name 기반으로 캐시 넣기
-    //// 캐시 name 별로 Redis에 캐시하고 있는 자료구조가 다름
-    //////// ex. Dowith 같은 경우, Hash 구조로 되어있음
-    //// Hash 구조에서 key 기반으로 value 가져오기
-    //// Hash 구조에서 key 기반으로 value 삭제하기
-    //// 과정에서
 
     public <T> T get(String cacheName, String key, Class<T> type) {
 
@@ -38,26 +31,27 @@ public class CacheHelper {
         } else {
             Cache cache = cacheManager.getCache(cacheName);
             if (cache == null) {
-                return null;
+                throw new IllegalStateException("No Cache found for cache name: " + cacheName);
             }
             return cache.get(key, type);
         }
     }
 
-    public <T> T get(String cacheName, String key, String field, Class<T> type) {
+    public <T> T get(String cacheName, String key, String field, Class<T> fieldType) {
 
         CachePolicy cachePolicy = CachePolicy.fromCacheName(cacheName);
+        String cacheKey = this.buildRedisKey(cacheName, key);
 
         if (cachePolicy.redisValueType().equals(RedisValueType.HASH)) {
-            Object value = redisTemplate.opsForHash().get(key, field);
+            Object value = redisTemplate.opsForHash().get(cacheKey, field);
             if (value == null) {
                 return null;
             }
 
-            if (type.isInstance(value)) {
-                return type.cast(value);
+            if (fieldType.isInstance(value)) {
+                return fieldType.cast(value);
             }
-            return objectMapper.convertValue(value, type);
+            return objectMapper.convertValue(value, fieldType);
         } else {
             throw new IllegalArgumentException("Cache type is not HASH for cache name: " + cacheName);
         }
@@ -76,9 +70,10 @@ public class CacheHelper {
                 mapValue = objectMapper.convertValue(value, Map.class);
             }
             redisTemplate.opsForHash().putAll(redisKey, mapValue);
+            redisTemplate.expire(redisKey, cachePolicy.ttl());
         } else {
             Cache cache = cacheManager.getCache(cacheName);
-            if (cache == null) throw new IllegalArgumentException("No Cache found for cache name: " + cacheName);
+            if (cache == null) throw new IllegalStateException("No Cache found for cache name: " + cacheName);
             cache.put(key, value);
         }
     }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheHelper.java
@@ -1,13 +1,12 @@
 package com.LetMeDoWith.LetMeDoWith.common.cache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -23,7 +22,8 @@ public class CacheHelper {
         CachePolicy cachePolicy = CachePolicy.fromCacheName(cacheName);
 
         if (cachePolicy.redisValueType().equals(RedisValueType.HASH)) {
-            Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
+            String redisKey = this.buildRedisKey(cacheName, key);
+            Map<Object, Object> entries = redisTemplate.opsForHash().entries(redisKey);
             if (entries.isEmpty()) {
                 return null;
             }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheName.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheName.java
@@ -1,0 +1,9 @@
+package com.LetMeDoWith.LetMeDoWith.common.cache;
+
+public final class CacheName {
+
+    // Social Provider Public Key Cache Names
+    public static final String APPLE_PUBLIC_KEY = "apple-public-key";
+    public static final String GOOGLE_PUBLIC_KEY = "google-public-key";
+    public static final String KAKAO_PUBLIC_KEY = "kakao-public-key";
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheName.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheName.java
@@ -6,4 +6,5 @@ public final class CacheName {
     public static final String APPLE_PUBLIC_KEY = "apple-public-key";
     public static final String GOOGLE_PUBLIC_KEY = "google-public-key";
     public static final String KAKAO_PUBLIC_KEY = "kakao-public-key";
+    public static final String DOWITH_TASK = "dowith";
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheName.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CacheName.java
@@ -7,4 +7,5 @@ public final class CacheName {
     public static final String GOOGLE_PUBLIC_KEY = "google-public-key";
     public static final String KAKAO_PUBLIC_KEY = "kakao-public-key";
     public static final String DOWITH_TASK = "dowith";
+    public static final String LAZY_DOWITH_TASK = "lazy-dowith";
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CachePolicy.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CachePolicy.java
@@ -1,0 +1,38 @@
+package com.LetMeDoWith.LetMeDoWith.common.cache;
+
+import java.time.Duration;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum CachePolicy {
+    APPLE_PUBLIC_KEY(CacheName.APPLE_PUBLIC_KEY, RedisValueType.STRING, Duration.ofMinutes(1L)),
+    GOOGLE_PUBLIC_KEY(CacheName.GOOGLE_PUBLIC_KEY, RedisValueType.STRING, Duration.ofMinutes(1L)),
+    KAKAO_PUBLIC_KEY(CacheName.KAKAO_PUBLIC_KEY, RedisValueType.STRING, Duration.ofMinutes(1L)),
+
+    DOWITH_TASK(CacheName.DOWITH_TASK, RedisValueType.HASH, Duration.ofDays(14));
+
+    private final String cacheName;
+    private final RedisValueType redisValueType;
+    private final Duration ttl;
+
+    public static CachePolicy fromCacheName(String cacheName) {
+        for (CachePolicy policy : CachePolicy.values()) {
+            if (policy.cacheName.equals(cacheName)) {
+                return policy;
+            }
+        }
+        throw new IllegalArgumentException("No CachePolicy found for cache name: " + cacheName);
+    }
+
+    public String cacheName() {
+        return cacheName;
+    }
+
+    public RedisValueType redisValueType() {
+        return redisValueType;
+    }
+
+    public Duration ttl() {
+        return ttl;
+    }
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CachePolicy.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CachePolicy.java
@@ -9,7 +9,8 @@ public enum CachePolicy {
     GOOGLE_PUBLIC_KEY(CacheName.GOOGLE_PUBLIC_KEY, RedisValueType.STRING, Duration.ofDays(7)),
     KAKAO_PUBLIC_KEY(CacheName.KAKAO_PUBLIC_KEY, RedisValueType.STRING, Duration.ofDays(7)),
 
-    DOWITH_TASK(CacheName.DOWITH_TASK, RedisValueType.HASH, Duration.ofDays(14));
+    DOWITH_TASK(CacheName.DOWITH_TASK, RedisValueType.HASH, Duration.ofDays(14)),
+    LAZY_DOWTIH_TASK(CacheName.LAZY_DOWITH_TASK, RedisValueType.LIST, null);
 
     private final String cacheName;
     private final RedisValueType redisValueType;

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CachePolicy.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/CachePolicy.java
@@ -5,9 +5,9 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum CachePolicy {
-    APPLE_PUBLIC_KEY(CacheName.APPLE_PUBLIC_KEY, RedisValueType.STRING, Duration.ofMinutes(1L)),
-    GOOGLE_PUBLIC_KEY(CacheName.GOOGLE_PUBLIC_KEY, RedisValueType.STRING, Duration.ofMinutes(1L)),
-    KAKAO_PUBLIC_KEY(CacheName.KAKAO_PUBLIC_KEY, RedisValueType.STRING, Duration.ofMinutes(1L)),
+    APPLE_PUBLIC_KEY(CacheName.APPLE_PUBLIC_KEY, RedisValueType.STRING, Duration.ofDays(7)),
+    GOOGLE_PUBLIC_KEY(CacheName.GOOGLE_PUBLIC_KEY, RedisValueType.STRING, Duration.ofDays(7)),
+    KAKAO_PUBLIC_KEY(CacheName.KAKAO_PUBLIC_KEY, RedisValueType.STRING, Duration.ofDays(7)),
 
     DOWITH_TASK(CacheName.DOWITH_TASK, RedisValueType.HASH, Duration.ofDays(14));
 

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/RedisValueType.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/RedisValueType.java
@@ -1,0 +1,6 @@
+package com.LetMeDoWith.LetMeDoWith.common.cache;
+
+public enum RedisValueType {
+    STRING,
+    HASH
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/RedisValueType.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/cache/RedisValueType.java
@@ -2,5 +2,6 @@ package com.LetMeDoWith.LetMeDoWith.common.cache;
 
 public enum RedisValueType {
     STRING,
-    HASH
+    HASH,
+    LIST
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/config/CacheConfig.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/config/CacheConfig.java
@@ -1,6 +1,6 @@
 package com.LetMeDoWith.LetMeDoWith.config;
 
-import com.LetMeDoWith.LetMeDoWith.domain.auth.enums.SocialProvider;
+import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,9 +32,9 @@ public class CacheConfig {
 
         Map<String, RedisCacheConfiguration> individualConfiguration = new HashMap<>();
         // TODO - 각 Social Provider 마다 API Refresh Time 고려하여 TTL 설정 변경 필요
-        individualConfiguration.put(SocialProvider.APPLE.getCode(), defaultConfig.entryTtl(Duration.ofMinutes(1L)));
-        individualConfiguration.put(SocialProvider.GOOGLE.getCode(), defaultConfig.entryTtl(Duration.ofMinutes(1L)));
-        individualConfiguration.put(SocialProvider.KAKAO.getCode(), defaultConfig.entryTtl(Duration.ofMinutes(1L)));
+        individualConfiguration.put(CacheName.APPLE_PUBLIC_KEY, defaultConfig.entryTtl(Duration.ofMinutes(1L)));
+        individualConfiguration.put(CacheName.GOOGLE_PUBLIC_KEY, defaultConfig.entryTtl(Duration.ofMinutes(1L)));
+        individualConfiguration.put(CacheName.KAKAO_PUBLIC_KEY, defaultConfig.entryTtl(Duration.ofMinutes(1L)));
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
                 .cacheDefaults(defaultConfig)

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/config/CacheConfig.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/config/CacheConfig.java
@@ -1,6 +1,6 @@
 package com.LetMeDoWith.LetMeDoWith.config;
 
-import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
+import com.LetMeDoWith.LetMeDoWith.common.cache.CachePolicy;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,22 +22,24 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class CacheConfig {
 
     @Bean
-    public CacheManager socialProviderPublicKeyCacheManager(RedisConnectionFactory cf) {
+    public CacheManager cacheManager(RedisConnectionFactory cf) {
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
                         new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofMinutes(1L)); // TODO - default TTL
+                .entryTtl(Duration.ofMinutes(1L));
 
         Map<String, RedisCacheConfiguration> individualConfiguration = new HashMap<>();
-        // TODO - 각 Social Provider 마다 API Refresh Time 고려하여 TTL 설정 변경 필요
-        individualConfiguration.put(CacheName.APPLE_PUBLIC_KEY, defaultConfig.entryTtl(Duration.ofMinutes(1L)));
-        individualConfiguration.put(CacheName.GOOGLE_PUBLIC_KEY, defaultConfig.entryTtl(Duration.ofMinutes(1L)));
-        individualConfiguration.put(CacheName.KAKAO_PUBLIC_KEY, defaultConfig.entryTtl(Duration.ofMinutes(1L)));
+        individualConfiguration.put(
+                CachePolicy.APPLE_PUBLIC_KEY.cacheName(), defaultConfig.entryTtl(CachePolicy.APPLE_PUBLIC_KEY.ttl()));
+        individualConfiguration.put(
+                CachePolicy.GOOGLE_PUBLIC_KEY.cacheName(), defaultConfig.entryTtl(CachePolicy.GOOGLE_PUBLIC_KEY.ttl()));
+        individualConfiguration.put(
+                CachePolicy.KAKAO_PUBLIC_KEY.cacheName(), defaultConfig.entryTtl(CachePolicy.KAKAO_PUBLIC_KEY.ttl()));
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
-                .cacheDefaults(defaultConfig)
+                //                .cacheDefaults(defaultConfig)
                 .withInitialCacheConfigurations(individualConfiguration)
                 .build();
     }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/config/CacheConfig.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/config/CacheConfig.java
@@ -31,13 +31,9 @@ public class CacheConfig {
                 .entryTtl(Duration.ofMinutes(1L));
 
         Map<String, RedisCacheConfiguration> individualConfiguration = new HashMap<>();
-        individualConfiguration.put(
-                CachePolicy.APPLE_PUBLIC_KEY.cacheName(), defaultConfig.entryTtl(CachePolicy.APPLE_PUBLIC_KEY.ttl()));
-        individualConfiguration.put(
-                CachePolicy.GOOGLE_PUBLIC_KEY.cacheName(), defaultConfig.entryTtl(CachePolicy.GOOGLE_PUBLIC_KEY.ttl()));
-        individualConfiguration.put(
-                CachePolicy.KAKAO_PUBLIC_KEY.cacheName(), defaultConfig.entryTtl(CachePolicy.KAKAO_PUBLIC_KEY.ttl()));
-
+        for (CachePolicy policy : CachePolicy.values()) {
+            individualConfiguration.put(policy.cacheName(), defaultConfig.entryTtl(policy.ttl()));
+        }
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
                 //                .cacheDefaults(defaultConfig)
                 .withInitialCacheConfigurations(individualConfiguration)

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/config/CacheConfig.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/config/CacheConfig.java
@@ -32,6 +32,9 @@ public class CacheConfig {
 
         Map<String, RedisCacheConfiguration> individualConfiguration = new HashMap<>();
         for (CachePolicy policy : CachePolicy.values()) {
+            if (policy.ttl() == null) {
+                continue;
+            }
             individualConfiguration.put(policy.cacheName(), defaultConfig.entryTtl(policy.ttl()));
         }
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/config/RedisConfig.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/config/RedisConfig.java
@@ -1,15 +1,19 @@
 package com.LetMeDoWith.LetMeDoWith.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
@@ -30,19 +34,33 @@ public class RedisConfig {
                 new RedisStandaloneConfiguration(redisProperties.getHost(), redisProperties.getPort()), clientConfig);
     }
 
-    // @Bean
-    // public RedisTemplate<String, Object> redisJsonTemplate() {
-    // RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-    // redisTemplate.setConnectionFactory(redisConnectionFactory());
-    // redisTemplate.setKeySerializer(new StringRedisSerializer());
-    // redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-    // return redisTemplate;
-    // }
-
     @Bean
-    public RedisTemplate<?, ?> redisTemplate() {
-        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
-        return redisTemplate;
+    public RedisTemplate<String, Object> redisTemplate(
+            RedisConnectionFactory redisConnectionFactory, ObjectMapper objectMapper) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+        GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        // key / value 직렬화 설정
+        template.setKeySerializer(stringSerializer);
+        template.setValueSerializer(jsonSerializer);
+
+        // HASH field / value 직렬화 설정
+        template.setHashKeySerializer(stringSerializer);
+        template.setHashValueSerializer(jsonSerializer);
+
+        template.afterPropertiesSet();
+        return template;
     }
+
+    //    @Bean
+    //    @Qualifier("legacyRedisTemplate")
+    //    public RedisTemplate<?, ?> legacyRedisTemplate() {
+    //        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+    //        redisTemplate.setConnectionFactory(redisConnectionFactory());
+    //        redisTemplate.afterPropertiesSet();
+    //        return redisTemplate;
+    //    }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/auth/client/GoogleAuthClient.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/auth/client/GoogleAuthClient.java
@@ -2,6 +2,7 @@ package com.LetMeDoWith.LetMeDoWith.infrastructure.auth.client;
 
 import com.LetMeDoWith.LetMeDoWith.application.auth.client.AuthClient;
 import com.LetMeDoWith.LetMeDoWith.application.auth.dto.OidcPublicKeyResDto;
+import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
@@ -14,7 +15,7 @@ import reactor.core.publisher.Mono;
 @Component
 @RequiredArgsConstructor
 @Profile("!dev")
-@CacheConfig(cacheNames = "GOOGLE", cacheManager = "socialProviderPublicKeyCacheManager")
+@CacheConfig(cacheNames = CacheName.GOOGLE_PUBLIC_KEY)
 public class GoogleAuthClient implements AuthClient {
 
     private final WebClient webClient;

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/auth/client/KakaoAuthClient.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/auth/client/KakaoAuthClient.java
@@ -2,6 +2,7 @@ package com.LetMeDoWith.LetMeDoWith.infrastructure.auth.client;
 
 import com.LetMeDoWith.LetMeDoWith.application.auth.client.AuthClient;
 import com.LetMeDoWith.LetMeDoWith.application.auth.dto.OidcPublicKeyResDto;
+import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
@@ -12,7 +13,7 @@ import reactor.core.publisher.Mono;
 
 @Component
 @RequiredArgsConstructor
-@CacheConfig(cacheNames = "KAKAO", cacheManager = "socialProviderPublicKeyCacheManager")
+@CacheConfig(cacheNames = CacheName.KAKAO_PUBLIC_KEY)
 public class KakaoAuthClient implements AuthClient {
 
     private final WebClient webClient;

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/CacheTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/CacheTest.java
@@ -1,11 +1,8 @@
 package com.LetMeDoWith.LetMeDoWith.common;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.LetMeDoWith.LetMeDoWith.common.cache.CacheHelper;
 import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
 import com.LetMeDoWith.LetMeDoWith.common.code.TestService;
-import java.util.UUID;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +14,10 @@ import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @SpringBootTest
@@ -51,7 +52,7 @@ public class CacheTest {
 
     @DisplayName("Spring Cache Cacheable을 통해서 데이터 삽입 후 CacheHelper를 통해 조회")
     @Test
-    void test1() {
+    void cacheRedisValueTypeString() {
         // given
         String keyString = UUID.randomUUID().toString();
         Long keyNumber = 123L;
@@ -69,7 +70,7 @@ public class CacheTest {
 
     @DisplayName("CacheHelper를 통해 Redis Value Type Hash로 삽입 후 조회")
     @Test
-    void test2() {
+    void cacheRedisValueTypeHash() {
         // given
         String dowithTaskId = UUID.randomUUID().toString();
         TestDto cacheTarget = TestDto.builder().str1(str1).str2(str2).num1(num1).build();
@@ -90,7 +91,9 @@ public class CacheTest {
     }
 
     @Builder
-    private record TestDto(String str1, String str2, int num1) {}
+    private record TestDto(String str1, String str2, int num1) {
+    }
 
-    record DifferentDTO(String val1, String val2) {}
+    record DifferentDTO(String val1, String val2) {
+    }
 }

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/CacheTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/CacheTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Slf4j
 @SpringBootTest
 @ActiveProfiles("test")
-public class RedisCacheTest {
+public class CacheTest {
 
     @Autowired
     private WebClient webClient;
@@ -72,13 +72,13 @@ public class RedisCacheTest {
     @Test
     void test2() {
         // given
-        String key = "test-hash-key";
+        String dowithTaskId = UUID.randomUUID().toString();
         TestDto cacheTarget = TestDto.builder().str1(str1).str2(str2).num1(num1).build();
 
         // when
-        cacheHelper.put(CacheName.DOWITH_TASK, key, cacheTarget);
-        String cachedStr1 = cacheHelper.get(CacheName.DOWITH_TASK, key, "str1", String.class);
-        int num1 = cacheHelper.get(CacheName.DOWITH_TASK, key, "num1", Integer.class);
+        cacheHelper.put(CacheName.DOWITH_TASK, dowithTaskId, cacheTarget);
+        String cachedStr1 = cacheHelper.get(CacheName.DOWITH_TASK, dowithTaskId, "str1", String.class);
+        int num1 = cacheHelper.get(CacheName.DOWITH_TASK, dowithTaskId, "num1", Integer.class);
 
         // then
         assertThat(cachedStr1).isEqualTo(this.str1);

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/CacheTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/CacheTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.LetMeDoWith.LetMeDoWith.common.cache.CacheHelper;
 import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
 import com.LetMeDoWith.LetMeDoWith.common.code.TestService;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
@@ -42,11 +43,18 @@ public class CacheTest {
     private String str2;
     private int num1;
 
+    private String str3;
+    private String str4;
+    private int num2;
+
     @BeforeEach
     void init() {
         this.str1 = this.testService.getStr1();
         this.str2 = this.testService.getStr2();
         this.num1 = this.testService.getNum1();
+        this.str3 = "anotherValue1";
+        this.str4 = "anotherValue2";
+        this.num2 = 200;
     }
 
     @DisplayName("Spring Cache Cacheable을 통해서 데이터 삽입 후 CacheHelper를 통해 조회")
@@ -87,6 +95,40 @@ public class CacheTest {
         assertThat(cachedTarget.str1()).isEqualTo(this.str1);
         assertThat(cachedTarget.str2()).isEqualTo(this.str2);
         assertThat(cachedTarget.num1()).isEqualTo(this.num1);
+    }
+
+    @DisplayName("CacheHelper를 통해 Redis Value Type List로 삽입 후 조회")
+    @Test
+    void cacheRedisValueTypeList() {
+        // given
+        String listKey = UUID.randomUUID().toString();
+        TestDto cacheTarget = new TestDto(str1, str2, num1);
+
+        // when
+        cacheHelper.push(CacheName.LAZY_DOWITH_TASK, listKey, cacheTarget);
+        List<TestDto> cachedTarget = cacheHelper.getByRange(CacheName.LAZY_DOWITH_TASK, listKey, 0, -1, TestDto.class);
+
+        // then
+        assertThat(cachedTarget.get(0)).isEqualTo(cacheTarget);
+    }
+
+    @DisplayName("CacheHelper를 통해 Redis Value Type List로 삽입 후 삭제")
+    @Test
+    void cacheRedisValueTypeListRemove() {
+        // given
+        String listKey = UUID.randomUUID().toString();
+        TestDto cacheTarget1 = new TestDto(str1, str2, num1);
+        TestDto cacheTarget2 = new TestDto(str3, str4, num2);
+
+        // when
+        cacheHelper.push(CacheName.LAZY_DOWITH_TASK, listKey, cacheTarget1);
+        cacheHelper.push(CacheName.LAZY_DOWITH_TASK, listKey, cacheTarget2);
+        cacheHelper.remove(CacheName.LAZY_DOWITH_TASK, listKey, cacheTarget1);
+        List<TestDto> cachedTarget = cacheHelper.getByRange(CacheName.LAZY_DOWITH_TASK, listKey, 0, -1, TestDto.class);
+
+        // then
+        assertThat(cachedTarget.size()).isEqualTo(1);
+        assertThat(cachedTarget.get(0)).isEqualTo(cacheTarget2);
     }
 
     @Builder

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/CacheTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/CacheTest.java
@@ -1,8 +1,11 @@
 package com.LetMeDoWith.LetMeDoWith.common;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.LetMeDoWith.LetMeDoWith.common.cache.CacheHelper;
 import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
 import com.LetMeDoWith.LetMeDoWith.common.code.TestService;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,10 +17,6 @@ import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.reactive.function.client.WebClient;
-
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @SpringBootTest
@@ -91,9 +90,7 @@ public class CacheTest {
     }
 
     @Builder
-    private record TestDto(String str1, String str2, int num1) {
-    }
+    private record TestDto(String str1, String str2, int num1) {}
 
-    record DifferentDTO(String val1, String val2) {
-    }
+    record DifferentDTO(String val1, String val2) {}
 }

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/CacheTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/CacheTest.java
@@ -1,8 +1,11 @@
 package com.LetMeDoWith.LetMeDoWith.common;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.LetMeDoWith.LetMeDoWith.common.cache.CacheHelper;
 import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
 import com.LetMeDoWith.LetMeDoWith.common.code.TestService;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,10 +17,6 @@ import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.reactive.function.client.WebClient;
-
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @SpringBootTest
@@ -80,15 +79,18 @@ public class CacheTest {
         String cachedStr1 = cacheHelper.get(CacheName.DOWITH_TASK, dowithTaskId, "str1", String.class);
         int num1 = cacheHelper.get(CacheName.DOWITH_TASK, dowithTaskId, "num1", Integer.class);
 
+        TestDto cachedTarget = cacheHelper.get(CacheName.DOWITH_TASK, dowithTaskId, TestDto.class);
+
         // then
         assertThat(cachedStr1).isEqualTo(this.str1);
         assertThat(num1).isEqualTo(this.num1);
+        assertThat(cachedTarget.str1()).isEqualTo(this.str1);
+        assertThat(cachedTarget.str2()).isEqualTo(this.str2);
+        assertThat(cachedTarget.num1()).isEqualTo(this.num1);
     }
 
     @Builder
-    private record TestDto(String str1, String str2, int num1) {
-    }
+    private record TestDto(String str1, String str2, int num1) {}
 
-    record DifferentDTO(String val1, String val2) {
-    }
+    record DifferentDTO(String val1, String val2) {}
 }

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/RedisCacheTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/RedisCacheTest.java
@@ -1,18 +1,31 @@
 package com.LetMeDoWith.LetMeDoWith.common;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
 import com.LetMeDoWith.LetMeDoWith.common.code.TestRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
 
 @Slf4j
 @SpringBootTest
+@ActiveProfiles("test")
 public class RedisCacheTest {
 
     @Autowired
     private TestRepository testRepository;
+
+    @Autowired
+    private RedisTemplate redisTemplate;
+
+    @Autowired
+    private CacheManager cacheManager;
 
     @Test
     void objectTypeCacheSuccessTest() throws InterruptedException {
@@ -27,8 +40,8 @@ public class RedisCacheTest {
         log.debug(result1.toString());
 
         // then
-        Assertions.assertThat(result2.val1()).isEqualTo(result1.val1());
-        Assertions.assertThat(result2.val2()).isEqualTo(result1.val2());
+        assertThat(result2.val1()).isEqualTo(result1.val1());
+        assertThat(result2.val2()).isEqualTo(result1.val2());
     }
 
     @Test
@@ -58,6 +71,17 @@ public class RedisCacheTest {
         TestRepository.TestResponseDto result2 = testRepository.testMono().block();
 
         // then
-        Assertions.assertThat(result2.toString()).isEqualTo(result1.toString());
+        assertThat(result2.toString()).isEqualTo(result1.toString());
+    }
+
+    @Test
+    void cacheManagerTest() throws InterruptedException {
+
+        TestRepository.TestDto result = testRepository.testObject();
+        Cache cache = cacheManager.getCache(CacheName.GOOGLE_PUBLIC_KEY);
+        TestRepository.TestDto testDto = cache.get("publicKey-String", TestRepository.TestDto.class);
+
+        assertThat(testDto.val1()).isEqualTo(result.val1());
+        assertThat(testDto.val2()).isEqualTo(result.val2());
     }
 }

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/RedisCacheTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/RedisCacheTest.java
@@ -2,9 +2,13 @@ package com.LetMeDoWith.LetMeDoWith.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.LetMeDoWith.LetMeDoWith.common.cache.CacheHelper;
 import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
-import com.LetMeDoWith.LetMeDoWith.common.code.TestRepository;
+import com.LetMeDoWith.LetMeDoWith.common.code.TestService;
+import jakarta.annotation.PostConstruct;
+import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,13 +23,27 @@ import org.springframework.test.context.ActiveProfiles;
 public class RedisCacheTest {
 
     @Autowired
-    private TestRepository testRepository;
+    private TestService testService;
 
     @Autowired
-    private RedisTemplate redisTemplate;
+    private RedisTemplate<?, ?> redisTemplate;
 
     @Autowired
     private CacheManager cacheManager;
+
+    @Autowired
+    private CacheHelper cacheHelper;
+
+    private String str1;
+    private String str2;
+    private int num1;
+
+    @PostConstruct
+    void init() {
+        this.str1 = this.testService.str1;
+        this.str2 = this.testService.str2;
+        this.num1 = this.testService.num1;
+    }
 
     @Test
     void objectTypeCacheSuccessTest() throws InterruptedException {
@@ -33,15 +51,15 @@ public class RedisCacheTest {
         // given
 
         // when
-        TestRepository.TestDto result1 = testRepository.testObject();
-        log.debug(result1.toString());
-        Thread.sleep(2000);
-        TestRepository.TestDto result2 = testRepository.testObject();
-        log.debug(result1.toString());
-
-        // then
-        assertThat(result2.val1()).isEqualTo(result1.val1());
-        assertThat(result2.val2()).isEqualTo(result1.val2());
+        //        TestService.TestDto result1 = testService.cacheObject();
+        //        log.debug(result1.toString());
+        //        Thread.sleep(2000);
+        //        TestService.TestDto result2 = testService.cacheObject();
+        //        log.debug(result1.toString());
+        //
+        //        // then
+        //        assertThat(result2.val1()).isEqualTo(result1.val1());
+        //        assertThat(result2.val2()).isEqualTo(result1.val2());
     }
 
     @Test
@@ -50,9 +68,9 @@ public class RedisCacheTest {
         // given
 
         // when
-        testRepository.testMono().subscribe(body -> log.debug(body.toString()));
+        testService.cacheMonoObject().subscribe(body -> log.debug(body.toString()));
         Thread.sleep(2000);
-        testRepository.testMono().subscribe(body -> log.debug(body.toString()));
+        testService.cacheMonoObject().subscribe(body -> log.debug(body.toString()));
 
         // then
         // Assertions.assertThat(result2.val1()).isEqualTo(result1.val1());
@@ -66,9 +84,9 @@ public class RedisCacheTest {
         // given
 
         // when
-        TestRepository.TestResponseDto result1 = testRepository.testMono().block();
+        TestService.TestResponseDto result1 = testService.cacheMonoObject().block();
         Thread.sleep(2000);
-        TestRepository.TestResponseDto result2 = testRepository.testMono().block();
+        TestService.TestResponseDto result2 = testService.cacheMonoObject().block();
 
         // then
         assertThat(result2.toString()).isEqualTo(result1.toString());
@@ -77,11 +95,31 @@ public class RedisCacheTest {
     @Test
     void cacheManagerTest() throws InterruptedException {
 
-        TestRepository.TestDto result = testRepository.testObject();
+        TestService.TestDto result = testService.cacheObject();
         Cache cache = cacheManager.getCache(CacheName.GOOGLE_PUBLIC_KEY);
-        TestRepository.TestDto testDto = cache.get("publicKey-String", TestRepository.TestDto.class);
+        Object object = cache.get("publicKey-String", Object.class);
 
-        assertThat(testDto.val1()).isEqualTo(result.val1());
-        assertThat(testDto.val2()).isEqualTo(result.val2());
+        //        assertThat(object.val1()).isEqualTo(result.val1());
+        //        assertThat(object.val2()).isEqualTo(result.val2());
     }
+
+    @DisplayName("Spring Cache Cacheable을 통해서 데이터 삽입 후 CacheHelper를 통해 조회")
+    @Test
+    void test1() {
+        // given
+        testService.cacheObject();
+        // when
+        TestService.TestDto cachedData =
+                cacheHelper.get(CacheName.GOOGLE_PUBLIC_KEY, "publicKey1", TestService.TestDto.class);
+
+        // then
+        assertThat(cachedData.str1()).isEqualTo(str1);
+        assertThat(cachedData.str2()).isEqualTo(str2);
+        assertThat(cachedData.num1()).isEqualTo(num1);
+    }
+
+    @Builder
+    private record TestDto(String str1, String str2, int num1) {}
+
+    record DifferentDTO(String val1, String val2) {}
 }

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/RedisCacheTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/RedisCacheTest.java
@@ -1,26 +1,31 @@
 package com.LetMeDoWith.LetMeDoWith.common;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.LetMeDoWith.LetMeDoWith.common.cache.CacheHelper;
 import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
 import com.LetMeDoWith.LetMeDoWith.common.code.TestService;
-import jakarta.annotation.PostConstruct;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @SpringBootTest
 @ActiveProfiles("test")
 public class RedisCacheTest {
+
+    @Autowired
+    private WebClient webClient;
 
     @Autowired
     private TestService testService;
@@ -38,79 +43,24 @@ public class RedisCacheTest {
     private String str2;
     private int num1;
 
-    @PostConstruct
+    @BeforeEach
     void init() {
-        this.str1 = this.testService.str1;
-        this.str2 = this.testService.str2;
-        this.num1 = this.testService.num1;
-    }
-
-    @Test
-    void objectTypeCacheSuccessTest() throws InterruptedException {
-
-        // given
-
-        // when
-        //        TestService.TestDto result1 = testService.cacheObject();
-        //        log.debug(result1.toString());
-        //        Thread.sleep(2000);
-        //        TestService.TestDto result2 = testService.cacheObject();
-        //        log.debug(result1.toString());
-        //
-        //        // then
-        //        assertThat(result2.val1()).isEqualTo(result1.val1());
-        //        assertThat(result2.val2()).isEqualTo(result1.val2());
-    }
-
-    @Test
-    void monoTypeNonBlockCacheSuccessTest() throws InterruptedException {
-
-        // given
-
-        // when
-        testService.cacheMonoObject().subscribe(body -> log.debug(body.toString()));
-        Thread.sleep(2000);
-        testService.cacheMonoObject().subscribe(body -> log.debug(body.toString()));
-
-        // then
-        // Assertions.assertThat(result2.val1()).isEqualTo(result1.val1());
-        // Assertions.assertThat(result2.val2()).isEqualTo(result1.val2());
-
-    }
-
-    @Test
-    void monoTypeBlockCacheSuccessTest() throws InterruptedException {
-
-        // given
-
-        // when
-        TestService.TestResponseDto result1 = testService.cacheMonoObject().block();
-        Thread.sleep(2000);
-        TestService.TestResponseDto result2 = testService.cacheMonoObject().block();
-
-        // then
-        assertThat(result2.toString()).isEqualTo(result1.toString());
-    }
-
-    @Test
-    void cacheManagerTest() throws InterruptedException {
-
-        TestService.TestDto result = testService.cacheObject();
-        Cache cache = cacheManager.getCache(CacheName.GOOGLE_PUBLIC_KEY);
-        Object object = cache.get("publicKey-String", Object.class);
-
-        //        assertThat(object.val1()).isEqualTo(result.val1());
-        //        assertThat(object.val2()).isEqualTo(result.val2());
+        this.str1 = this.testService.getStr1();
+        this.str2 = this.testService.getStr2();
+        this.num1 = this.testService.getNum1();
     }
 
     @DisplayName("Spring Cache Cacheable을 통해서 데이터 삽입 후 CacheHelper를 통해 조회")
     @Test
     void test1() {
         // given
-        testService.cacheObject();
+        String keyString = UUID.randomUUID().toString();
+        Long keyNumber = 123L;
+        testService.cacheObject(keyString, keyNumber);
+        String key = keyString + "::" + keyNumber;
+
         // when
-        TestService.TestDto cachedData =
-                cacheHelper.get(CacheName.GOOGLE_PUBLIC_KEY, "publicKey1", TestService.TestDto.class);
+        TestService.TestDto cachedData = cacheHelper.get(CacheName.GOOGLE_PUBLIC_KEY, key, TestService.TestDto.class);
 
         // then
         assertThat(cachedData.str1()).isEqualTo(str1);
@@ -118,8 +68,27 @@ public class RedisCacheTest {
         assertThat(cachedData.num1()).isEqualTo(num1);
     }
 
-    @Builder
-    private record TestDto(String str1, String str2, int num1) {}
+    @DisplayName("CacheHelper를 통해 Redis Value Type Hash로 삽입 후 조회")
+    @Test
+    void test2() {
+        // given
+        String key = "test-hash-key";
+        TestDto cacheTarget = TestDto.builder().str1(str1).str2(str2).num1(num1).build();
 
-    record DifferentDTO(String val1, String val2) {}
+        // when
+        cacheHelper.put(CacheName.DOWITH_TASK, key, cacheTarget);
+        String cachedStr1 = cacheHelper.get(CacheName.DOWITH_TASK, key, "str1", String.class);
+        int num1 = cacheHelper.get(CacheName.DOWITH_TASK, key, "num1", Integer.class);
+
+        // then
+        assertThat(cachedStr1).isEqualTo(this.str1);
+        assertThat(num1).isEqualTo(this.num1);
+    }
+
+    @Builder
+    private record TestDto(String str1, String str2, int num1) {
+    }
+
+    record DifferentDTO(String val1, String val2) {
+    }
 }

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/code/TestRepository.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/code/TestRepository.java
@@ -1,5 +1,6 @@
 package com.LetMeDoWith.LetMeDoWith.common.code;
 
+import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Builder;
@@ -16,14 +17,12 @@ import reactor.core.publisher.Mono;
 @Slf4j
 @Repository
 @RequiredArgsConstructor
-@CacheConfig(cacheNames = "APPLE", cacheManager = "socialProviderPublicKeyCacheManager")
+@CacheConfig(cacheNames = CacheName.GOOGLE_PUBLIC_KEY)
 public class TestRepository {
 
+    private static final String testUrl = "https://jsonplaceholder.typicode.com/todos/1";
     private final WebClient webClient;
-
-    private static String testUrl = "https://jsonplaceholder.typicode.com/todos/1";
-
-    private Map<String, Object> store = new HashMap<>();
+    private final Map<String, Object> store = new HashMap<>();
 
     @Cacheable(key = "'publicKey-String'")
     public TestDto testObject() {
@@ -48,7 +47,7 @@ public class TestRepository {
     }
 
     @Builder
-    public static record TestDto(String val1, String val2) {}
+    public record TestDto(String val1, String val2) {}
 
     public record TestResponseDto(Long userId, Long id, String title, Boolean completed) {}
 }

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/code/TestService.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/code/TestService.java
@@ -6,34 +6,40 @@ import java.util.Map;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 @Slf4j
-@Repository
+@Service
 @RequiredArgsConstructor
-@CacheConfig(cacheNames = CacheName.GOOGLE_PUBLIC_KEY)
-public class TestRepository {
+public class TestService {
 
     private static final String testUrl = "https://jsonplaceholder.typicode.com/todos/1";
     private final WebClient webClient;
     private final Map<String, Object> store = new HashMap<>();
 
-    @Cacheable(key = "'publicKey-String'")
-    public TestDto testObject() {
+    public String str1 = "value1";
+    public String str2 = "value2";
+    public int num1 = 100;
+
+    @Cacheable(cacheNames = CacheName.GOOGLE_PUBLIC_KEY, key = "'publicKey1'")
+    public TestDto cacheObject() {
         log.debug(">>>Test Method executed");
-        TestDto testDto = TestDto.builder().val1("value1").val2("value2").build();
+        TestDto testDto = TestDto.builder()
+                .str1(this.str1)
+                .str2(this.str2)
+                .num1(this.num1)
+                .build();
         store.put("testData", testDto);
         return testDto;
     }
 
-    @Cacheable(key = "'publicKey-Mono'")
-    public Mono<TestResponseDto> testMono() {
+    @Cacheable(cacheNames = CacheName.GOOGLE_PUBLIC_KEY, key = "'publicKey2'")
+    public Mono<TestResponseDto> cacheMonoObject() {
         log.debug(">>>TestMono Method executed");
         return webClient
                 .get()
@@ -47,7 +53,7 @@ public class TestRepository {
     }
 
     @Builder
-    public record TestDto(String val1, String val2) {}
+    public record TestDto(String str1, String str2, int num1) {}
 
     public record TestResponseDto(Long userId, Long id, String title, Boolean completed) {}
 }

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/code/TestService.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/code/TestService.java
@@ -4,6 +4,7 @@ import com.LetMeDoWith.LetMeDoWith.common.cache.CacheName;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -15,6 +16,7 @@ import reactor.core.publisher.Mono;
 
 @Slf4j
 @Service
+@Getter
 @RequiredArgsConstructor
 public class TestService {
 
@@ -22,12 +24,12 @@ public class TestService {
     private final WebClient webClient;
     private final Map<String, Object> store = new HashMap<>();
 
-    public String str1 = "value1";
-    public String str2 = "value2";
-    public int num1 = 100;
+    private final String str1 = "value1";
+    private final String str2 = "value2";
+    private final int num1 = 100;
 
-    @Cacheable(cacheNames = CacheName.GOOGLE_PUBLIC_KEY, key = "'publicKey1'")
-    public TestDto cacheObject() {
+    @Cacheable(cacheNames = CacheName.GOOGLE_PUBLIC_KEY, key = "#keyString + '::' + #keyNumber")
+    public TestDto cacheObject(String keyString, Long keyNumber) {
         log.debug(">>>Test Method executed");
         TestDto testDto = TestDto.builder()
                 .str1(this.str1)

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/task/RetrieveTaskIntegrationTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/task/RetrieveTaskIntegrationTest.java
@@ -1,5 +1,9 @@
 package com.LetMeDoWith.LetMeDoWith.integration.task;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.LetMeDoWith.LetMeDoWith.common.util.DateTimeUtil;
 import com.LetMeDoWith.LetMeDoWith.common.util.SystemTimeUtil;
 import com.LetMeDoWith.LetMeDoWith.domain.task.enums.TaskRoutineCycle;
@@ -14,6 +18,9 @@ import com.LetMeDoWith.LetMeDoWith.integration.AbstractIntegrationTest;
 import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.RetrieveTasksResDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.RetrieveTasksResDto.TodoTaskDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.RetrieveTodoTaskResDto;
+import java.io.UnsupportedEncodingException;
+import java.time.*;
+import java.util.List;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -21,14 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.ResultActions;
-
-import java.io.UnsupportedEncodingException;
-import java.time.*;
-import java.util.List;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class RetrieveTaskIntegrationTest extends AbstractIntegrationTest {
 
@@ -237,7 +236,6 @@ public class RetrieveTaskIntegrationTest extends AbstractIntegrationTest {
                         .value(dowithTask1.getRoutine().getCycle().getCode()))
                 .andExpect(jsonPath("$.data.routineCondition.pattern").doesNotExist())
                 .andExpect(jsonPath("$.data.routineCondition.isExcludeHolidays").value(false));
-
     }
 
     @Test
@@ -248,7 +246,7 @@ public class RetrieveTaskIntegrationTest extends AbstractIntegrationTest {
         LocalDate endDate = LocalDate.of(2024, 3, 31);
 
         MockHttpServletResponse response = request(
-                get(RETRIEVE_TASKS_URL).param("year", "2024").param("month", "3"))
+                        get(RETRIEVE_TASKS_URL).param("year", "2024").param("month", "3"))
                 .andReturn()
                 .getResponse();
 
@@ -265,7 +263,7 @@ public class RetrieveTaskIntegrationTest extends AbstractIntegrationTest {
 
         // when
         MockHttpServletResponse singleRetrieveResponse = request(
-                get(RETRIEVE_SINGLE_TODO_URL + "/" + todoTaskDto.id().toString()))
+                        get(RETRIEVE_SINGLE_TODO_URL + "/" + todoTaskDto.id().toString()))
                 .andReturn()
                 .getResponse();
         singleRetrieveResponse.setCharacterEncoding("UTF-8");


### PR DESCRIPTION
## PR 체크리스트

Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [x] 모든 Test 코드를 실행하여 PASS했나요?
- [ ] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

PR의 타입을 체크해주세요

- [ ] 버그 픽스 - 이슈 링크 :
- [x] 신규 기능 개발
- [ ] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [ ] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타

## 백로그 및 이슈 링크

- 링크 : 캐시 공통

## 변경된 사항

### CacheName, CachePolicy

- Redis에 적재되는 데이터의 key는 `CacheName::`이 prefix로 붙음
- CacheName 기준으로 해당 데이터가 Redis에 어떤 value type(STRING, HASH) 로 적재될지 / TTL은 얼마일지 결정됨
- 해당 부분을 CachePolicy로 정책화함


### CacheHelper

- RedisTemplate / CacheManager 를 렛미두윗 캐싱 요구사항에 맞게 추상화
- CachePolicy 를 정책으로 참조하여 각 CacheName별 캐시 get / put 액션 수행
```
- KEY -> STRING Redis Value Type으로 캐싱 가능 : put
- KEY -> HASH Redis Value Type으로 캐싱 가능 : put
- STRING Redis Value Type을 DTO Object 형태로 캐시 조회 : get
- HASH Redis Value Type을 DTO Object 형태로 캐시 조회 : get
- HASH Redis Value Type의 각 field를 primitive 형태로 각 field의 value 조회
```

### 예상 개발자 개발 시나리오
```
<개발자 개발 시나리오>
1. 캐싱 요구사항 접수
2. CacheName 생성
3. CacheName 기반으로 CachePolicy Enum에 RedisValueType, TTL 과 함께 Enum 생성
4. CacheHelper / Spring Data (@Cacheable 어노테이션등) 을 사용하여 캐싱 작업 진행
```

<img width="656" height="383" alt="스크린샷 2025-12-11 오전 1 39 13" src="https://github.com/user-attachments/assets/6381a288-0461-4441-82e1-8303bb9aa1c2" />

<img width="642" height="306" alt="스크린샷 2025-12-11 오전 1 39 29" src="https://github.com/user-attachments/assets/6c6938a0-4155-4dfa-921c-6497a8e1705e" />

## 기타 전달 사항

- 현재 구조 괜찮으면, CacheHelper에 cache 삭제 메서드 / HASH Redis value Type일때 field 개별 update 메서드도 추가 예정
- 
