### PR TITLE
[TAS-557] S3 Presigned URL 발급 로직 공통화 & 멤버 프로필 이미지 Presigned URL 발급 API

### DIFF
--- a/resource-docker/local/docker-compose.yml
+++ b/resource-docker/local/docker-compose.yml
@@ -13,8 +13,27 @@ services:
       - LMDW
     volumes:
       - mysql-data:/var/lib/mysql
-      # Mount the external volume for MySQL data storage
-      # Mount the SQL script for initialization
+
+  mysql-init:
+    image: mysql:latest
+    depends_on:
+      - mysql-db
+    entrypoint:
+      - sh
+      - -c
+      - |
+        until mysqladmin ping -h mysql-db -uroot -pletmedowith_db_adm --silent; do
+          sleep 1
+        done
+        mysql -h mysql-db -uroot -pletmedowith_db_adm -e "
+          CREATE DATABASE IF NOT EXISTS letmedowith_test
+            CHARACTER SET utf8mb4
+            COLLATE utf8mb4_0900_ai_ci;
+          GRANT ALL PRIVILEGES ON letmedowith_test.* TO 'letmedowith'@'%';
+          FLUSH PRIVILEGES;
+        "
+    networks:
+      - LMDW
 
   redis-server:
     image: redis:latest

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/member/service/MemberService.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/member/service/MemberService.java
@@ -2,9 +2,12 @@ package com.LetMeDoWith.LetMeDoWith.application.member.service;
 
 import com.LetMeDoWith.LetMeDoWith.application.member.dto.CreateSignupCompletedMemberCommand;
 import com.LetMeDoWith.LetMeDoWith.application.member.dto.MemberPersonalInfoVO;
+import com.LetMeDoWith.LetMeDoWith.common.dto.GenerateUploadPresignedUrlsResult;
+import com.LetMeDoWith.LetMeDoWith.common.enums.common.FileNamespace;
 import com.LetMeDoWith.LetMeDoWith.common.enums.member.MemberStatus;
 import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
 import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
+import com.LetMeDoWith.LetMeDoWith.common.service.PresignedUrlService;
 import com.LetMeDoWith.LetMeDoWith.common.util.AuthUtil;
 import com.LetMeDoWith.LetMeDoWith.domain.auth.enums.SocialProvider;
 import com.LetMeDoWith.LetMeDoWith.domain.member.model.Member;
@@ -24,6 +27,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberSettingRepository memberSettingRepository;
+    private final PresignedUrlService presignedUrlService;
 
     /**
      * (Provider, Subject) 의 조합으로 기 가입된 계정이 존재하는지 확인한다.
@@ -140,6 +144,14 @@ public class MemberService {
         memberRepository.save(member);
     }
 
+    /**
+     * 회원의 프로필 정보를 업데이트합니다.
+     *
+     * @param memberId 업데이트 대상 회원 id
+     * @param nickname 변경할 닉네임
+     * @param selfDescription 변경할 자기소개
+     * @param profileImageUrl 변경할 프로필 이미지 URL
+     */
     @Transactional
     public void updateMemberInfo(String memberId, String nickname, String selfDescription, String profileImageUrl) {
         Member member = memberRepository
@@ -149,5 +161,24 @@ public class MemberService {
         member.updateMemberInfo(nickname, selfDescription, profileImageUrl);
 
         memberRepository.save(member);
+    }
+
+    /**
+     * 회원 프로필 이미지 업로드를 위한 presigned URL을 발급합니다.
+     *
+     * <p>실제 업로드 권한 확인은 NORMAL 회원 여부만 검증하고, key 생성 및 URL 발급은 공통 서비스에 위임합니다.
+     *
+     * @param memberId 프로필 이미지를 업로드하려는 회원 id
+     * @param imageFileName 업로드할 프로필 이미지 파일명
+     * @return 프로필 이미지 업로드용 presigned URL 결과
+     */
+    public GenerateUploadPresignedUrlsResult generateMemberProfileImageUploadPresignedUrl(
+            String memberId, String imageFileName) {
+        memberRepository
+                .getMember(memberId, MemberStatus.NORMAL)
+                .orElseThrow(() -> new RestApiException(FailResponseStatus.INVALID_REQUEST));
+
+        return presignedUrlService.generateUploadPresignedUrls(
+                FileNamespace.MEMBER_PROFILE, java.util.List.of(imageFileName));
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/task/client/FileClient.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/task/client/FileClient.java
@@ -1,8 +1,0 @@
-package com.LetMeDoWith.LetMeDoWith.application.task.client;
-
-import java.time.Duration;
-
-public interface FileClient {
-
-    String getUploadPresignedUrl(String key, Duration expires);
-}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/task/service/SuccessDowithTaskService.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/task/service/SuccessDowithTaskService.java
@@ -1,11 +1,13 @@
 package com.LetMeDoWith.LetMeDoWith.application.task.service;
 
-import com.LetMeDoWith.LetMeDoWith.application.task.client.FileClient;
 import com.LetMeDoWith.LetMeDoWith.application.task.dto.CancelLikeSuccessDowithTaskResult;
 import com.LetMeDoWith.LetMeDoWith.application.task.dto.LikeSuccessDowithTaskResult;
 import com.LetMeDoWith.LetMeDoWith.application.task.dto.RetrieveSuccessDowithTasksResult;
+import com.LetMeDoWith.LetMeDoWith.common.dto.GenerateUploadPresignedUrlsResult;
+import com.LetMeDoWith.LetMeDoWith.common.enums.common.FileNamespace;
 import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
 import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
+import com.LetMeDoWith.LetMeDoWith.common.service.PresignedUrlService;
 import com.LetMeDoWith.LetMeDoWith.domain.task.enums.DowithTaskStatus;
 import com.LetMeDoWith.LetMeDoWith.domain.task.model.DowithTask;
 import com.LetMeDoWith.LetMeDoWith.domain.task.model.DowithTaskLike;
@@ -13,7 +15,6 @@ import com.LetMeDoWith.LetMeDoWith.domain.task.repository.DowithTaskLikeReposito
 import com.LetMeDoWith.LetMeDoWith.domain.task.repository.DowithTaskQueryRepository;
 import com.LetMeDoWith.LetMeDoWith.domain.task.repository.DowithTaskRepository;
 import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.SuccessDowithTaskQueryDto;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -31,23 +32,22 @@ public class SuccessDowithTaskService {
     private final DowithTaskRepository dowithTaskRepository;
     private final DowithTaskQueryRepository dowithTaskQueryRepository;
     private final DowithTaskLikeRepository dowithTaskLikeRepository;
-    private final FileClient fileClient;
+    private final PresignedUrlService presignedUrlService;
 
     @Lazy
     @Autowired
     private SuccessDowithTaskService self;
 
-    public List<String> generateDowithTaskSuccessImageUploadPresignedUrls(
+    public GenerateUploadPresignedUrlsResult generateDowithTaskSuccessImageUploadPresignedUrls(
             String memberId, Long dowithTaskId, List<String> imageFileNames) {
 
         DowithTask dowithTask = dowithTaskRepository
                 .getDowithTask(dowithTaskId, memberId)
                 .orElseThrow(() -> new RestApiException(FailResponseStatus.INVALID_REQUEST));
 
-        List<String> keys = dowithTask.generateSuccessImageKey(imageFileNames);
-        return keys.stream()
-                .map(key -> fileClient.getUploadPresignedUrl(key, Duration.ofSeconds(30)))
-                .toList();
+        dowithTask.validateSuccessImageUploadAvailable();
+
+        return presignedUrlService.generateUploadPresignedUrls(FileNamespace.DOWITH_TASK_CONFIRM, imageFileNames);
     }
 
     @Transactional

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/dto/GenerateUploadPresignedUrlsResult.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/dto/GenerateUploadPresignedUrlsResult.java
@@ -1,0 +1,13 @@
+package com.LetMeDoWith.LetMeDoWith.common.dto;
+
+import java.util.List;
+
+/**
+ * 업로드용 presigned URL 발급 결과를 표현합니다.
+ *
+ * @param publicImageUrls query string이 제거된 공개 URL 목록
+ * @param presignedUrls 실제 업로드 요청에 사용할 presigned URL 목록
+ * @param method 업로드에 사용할 HTTP method
+ */
+public record GenerateUploadPresignedUrlsResult(
+        List<String> publicImageUrls, List<String> presignedUrls, String method) {}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/enums/common/FileNamespace.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/enums/common/FileNamespace.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum FileNamespace {
-    DOWITH_TASK_CONFIRM("dowith_task_confirms");
+    DOWITH_TASK_CONFIRM("dowith_task_confirms"),
+    MEMBER_PROFILE("member_profiles");
 
     private final String prefix;
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/enums/common/FileNamespace.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/enums/common/FileNamespace.java
@@ -1,0 +1,15 @@
+package com.LetMeDoWith.LetMeDoWith.common.enums.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 업로드 파일이 저장될 S3 prefix namespace를 정의합니다.
+ */
+@AllArgsConstructor
+@Getter
+public enum FileNamespace {
+    DOWITH_TASK_CONFIRM("dowith_task_confirms");
+
+    private final String prefix;
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/service/FileClient.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/service/FileClient.java
@@ -1,0 +1,18 @@
+package com.LetMeDoWith.LetMeDoWith.common.service;
+
+import java.time.Duration;
+
+/**
+ * 파일 업로드용 presigned URL 발급 구현을 추상화한 포트입니다.
+ */
+public interface FileClient {
+
+    /**
+     * 지정한 S3 key에 대해 업로드용 presigned URL을 발급합니다.
+     *
+     * @param key 업로드 대상 key
+     * @param expires presigned URL 만료 시간
+     * @return 업로드에 사용할 presigned URL
+     */
+    String getUploadPresignedUrl(String key, Duration expires);
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/service/PresignedUrlService.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/service/PresignedUrlService.java
@@ -1,0 +1,79 @@
+package com.LetMeDoWith.LetMeDoWith.common.service;
+
+import static com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus.INVALID_REQUEST;
+
+import com.LetMeDoWith.LetMeDoWith.common.dto.GenerateUploadPresignedUrlsResult;
+import com.LetMeDoWith.LetMeDoWith.common.enums.common.FileNamespace;
+import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
+import com.LetMeDoWith.LetMeDoWith.common.util.FileKeyUtil;
+import java.time.Duration;
+import java.util.List;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+/**
+ * 업로드 대상 파일명과 namespace를 받아 S3 업로드용 presigned URL 응답을 생성합니다.
+ *
+ * <p>비즈니스 도메인 검증은 각 도메인 서비스가 담당하고, 이 서비스는 공통 파일명 검증, key 생성,
+ * presigned/public URL 조립만 담당합니다.
+ */
+public class PresignedUrlService {
+
+    private static final Duration DEFAULT_UPLOAD_PRESIGNED_URL_EXPIRES = Duration.ofSeconds(30);
+    private static final Pattern VALID_IMAGE_FILE_NAME_PATTERN =
+            Pattern.compile("(?i)^.+\\.(jpg|jpeg|png|gif|bmp|webp)$");
+    private static final String UPLOAD_METHOD = "POST";
+
+    private final FileClient fileClient;
+
+    /**
+     * namespace와 파일명 목록을 기준으로 업로드용 presigned URL 응답을 생성합니다.
+     *
+     * @param fileNamespace 업로드 파일이 속한 namespace
+     * @param fileNames 업로드할 원본 파일명 목록
+     * @return public URL, presigned URL, 업로드 method를 포함한 결과
+     */
+    public GenerateUploadPresignedUrlsResult generateUploadPresignedUrls(
+            FileNamespace fileNamespace, List<String> fileNames) {
+
+        validateImageFileNames(fileNames);
+
+        List<String> keys = FileKeyUtil.generateKeys(fileNamespace, fileNames);
+        List<String> presignedUrls = keys.stream()
+                .map(key -> fileClient.getUploadPresignedUrl(key, DEFAULT_UPLOAD_PRESIGNED_URL_EXPIRES))
+                .toList();
+        List<String> publicImageUrls = presignedUrls.stream()
+                .map(PresignedUrlService::extractPublicUrl)
+                .toList();
+
+        return new GenerateUploadPresignedUrlsResult(publicImageUrls, presignedUrls, UPLOAD_METHOD);
+    }
+
+    /**
+     * 이미지 업로드에 허용된 파일명인지 검증합니다.
+     *
+     * @param fileNames 업로드할 파일명 목록
+     */
+    private void validateImageFileNames(List<String> fileNames) {
+        if (fileNames == null
+                || fileNames.isEmpty()
+                || fileNames.stream()
+                        .anyMatch(name ->
+                                !VALID_IMAGE_FILE_NAME_PATTERN.matcher(name).matches())) {
+            throw new RestApiException(INVALID_REQUEST);
+        }
+    }
+
+    /**
+     * presigned URL에서 서명 query string을 제거해 공개 접근용 URL 형태로 변환합니다.
+     *
+     * @param presignedUrl presigned URL
+     * @return query string이 제거된 공개 URL
+     */
+    private static String extractPublicUrl(String presignedUrl) {
+        return presignedUrl.contains("?") ? presignedUrl.substring(0, presignedUrl.indexOf('?')) : presignedUrl;
+    }
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/common/util/FileKeyUtil.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/common/util/FileKeyUtil.java
@@ -1,0 +1,45 @@
+package com.LetMeDoWith.LetMeDoWith.common.util;
+
+import com.LetMeDoWith.LetMeDoWith.common.enums.common.FileNamespace;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 파일 namespace와 원본 파일명을 기반으로 S3 key를 생성합니다.
+ */
+public final class FileKeyUtil {
+
+    private static final DateTimeFormatter FILE_KEY_TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMMddHHmmss'Z'");
+
+    private FileKeyUtil() {}
+
+    /**
+     * 파일명 목록에 대응하는 S3 key 목록을 생성합니다.
+     *
+     * @param fileNamespace 업로드 파일 namespace
+     * @param fileNames 원본 파일명 목록
+     * @return 생성된 S3 key 목록
+     */
+    public static List<String> generateKeys(FileNamespace fileNamespace, List<String> fileNames) {
+        return fileNames.stream()
+                .map(fileName -> generateKey(fileNamespace, fileName))
+                .toList();
+    }
+
+    /**
+     * 단일 파일명에 대한 S3 key를 생성합니다.
+     *
+     * @param fileNamespace 업로드 파일 namespace
+     * @param fileName 원본 파일명
+     * @return 생성된 S3 key
+     */
+    private static String generateKey(FileNamespace fileNamespace, String fileName) {
+        String timestamp = SystemTimeUtil.now().format(FILE_KEY_TIMESTAMP_FORMATTER);
+        String uuid = UUID.randomUUID().toString();
+        int shardIndex = Math.floorMod(uuid.hashCode(), 16);
+
+        return String.format("%s/%02d/%s_%s_%s", fileNamespace.getPrefix(), shardIndex, timestamp, uuid, fileName);
+    }
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/task/model/DowithTask.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/task/model/DowithTask.java
@@ -15,8 +15,6 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
-import java.util.regex.Pattern;
 import lombok.*;
 
 @Entity
@@ -271,14 +269,7 @@ public class DowithTask extends BaseAuditEntity {
      * @param imageFileNames
      * @return
      */
-    public List<String> generateSuccessImageKey(List<String> imageFileNames) {
-
-        Pattern validExtensions = Pattern.compile("(?i)^.+\\.(jpg|jpeg|png|gif|bmp|webp)$");
-        if (imageFileNames.stream()
-                .anyMatch(name -> !validExtensions.matcher(name).matches())) {
-            throw new RestApiException(INVALID_REQUEST);
-        }
-
+    public void validateSuccessImageUploadAvailable() {
         if (!status.equals(DowithTaskStatus.WAIT)) {
             throw new RestApiException(INVALID_REQUEST);
         }
@@ -286,18 +277,6 @@ public class DowithTask extends BaseAuditEntity {
         if (SystemTimeUtil.now().isAfter(LocalDateTime.of(this.date, this.startTime))) {
             throw new RestApiException(INVALID_REQUEST);
         }
-
-        int shardIndex = (int) (this.id % 16);
-
-        List<String> successImageKeys = new ArrayList<>();
-        for (String imageFileName : imageFileNames) {
-            String timestamp =
-                    SystemTimeUtil.now().toString().replace("[:\\-T]", "").substring(0, 14) + "Z";
-            String uuid = UUID.randomUUID().toString();
-            successImageKeys.add(
-                    String.format("dowith_task_confirms/%02d/%s_%s.%s", shardIndex, timestamp, uuid, imageFileName));
-        }
-        return successImageKeys;
     }
 
     /**

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/file/client/AwsS3FileClient.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/file/client/AwsS3FileClient.java
@@ -1,6 +1,6 @@
-package com.LetMeDoWith.LetMeDoWith.infrastructure.task.client;
+package com.LetMeDoWith.LetMeDoWith.infrastructure.file.client;
 
-import com.LetMeDoWith.LetMeDoWith.application.task.client.FileClient;
+import com.LetMeDoWith.LetMeDoWith.common.service.FileClient;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +19,7 @@ public class AwsS3FileClient implements FileClient {
     @Value("${cloud.aws.s3.bucketName}")
     private String bucketName;
 
+    @Override
     public String getUploadPresignedUrl(String key, Duration expires) {
         PutObjectRequest putObjectRequest =
                 PutObjectRequest.builder().bucket(bucketName).key(key).build();

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.LetMeDoWith.LetMeDoWith.application.member.service.MemberService;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponse;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponses;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiSuccessResponse;
+import com.LetMeDoWith.LetMeDoWith.common.dto.GenerateUploadPresignedUrlsResult;
 import com.LetMeDoWith.LetMeDoWith.common.dto.ResponseDto;
 import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
 import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
@@ -16,6 +17,8 @@ import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
 import com.LetMeDoWith.LetMeDoWith.domain.member.model.Member;
 import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenResDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.CheckNicknameReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.GenerateMemberProfileImageUploadPresignedUrlReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.GenerateMemberProfileImageUploadPresignedUrlResDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.SignupCompleteReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.UpdateMemberInfoReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.UpdateMemberTermAgreeReqDto;
@@ -152,5 +155,21 @@ public class MemberController {
                 updateMemberInfoReqDto.selfDescription(),
                 updateMemberInfoReqDto.profileImageUrl());
         return ResponseUtil.createSuccessResponse(SuccessResponseStatus.OK);
+    }
+
+    @Operation(summary = "프로필 이미지 upload presigned url 발급")
+    @ApiSuccessResponse(description = "프로필 이미지 업로드용 presigned url 발급 성공")
+    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
+    @PostMapping("/profile-image/upload-presigned-url")
+    public ResponseEntity<ResponseDto<GenerateMemberProfileImageUploadPresignedUrlResDto>>
+            generateMemberProfileImageUploadPresignedUrl(
+                    @RequestBody GenerateMemberProfileImageUploadPresignedUrlReqDto requestBody) {
+        String memberId = AuthUtil.getMemberId();
+
+        GenerateUploadPresignedUrlsResult result =
+                memberService.generateMemberProfileImageUploadPresignedUrl(memberId, requestBody.imageFileName());
+
+        return ResponseUtil.createSuccessResponse(new GenerateMemberProfileImageUploadPresignedUrlResDto(
+                result.publicImageUrls().get(0), result.presignedUrls().get(0), result.method()));
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/GenerateMemberProfileImageUploadPresignedUrlReqDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/GenerateMemberProfileImageUploadPresignedUrlReqDto.java
@@ -1,0 +1,6 @@
+package com.LetMeDoWith.LetMeDoWith.presentation.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GenerateMemberProfileImageUploadPresignedUrlReqDto(
+        @Schema(description = "업로드할 프로필 이미지 파일 이름(확장자 포함)", example = "profile.png") String imageFileName) {}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/GenerateMemberProfileImageUploadPresignedUrlResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/GenerateMemberProfileImageUploadPresignedUrlResDto.java
@@ -1,0 +1,8 @@
+package com.LetMeDoWith.LetMeDoWith.presentation.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GenerateMemberProfileImageUploadPresignedUrlResDto(
+        @Schema(description = "업로드 후 저장될 프로필 이미지 공개 URL") String publicImageUrl,
+        @Schema(description = "실제 업로드 요청에 사용할 presigned URL") String presignedUrl,
+        @Schema(description = "업로드에 사용할 HTTP method") String method) {}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/task/controller/DowithTaskController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/task/controller/DowithTaskController.java
@@ -13,6 +13,7 @@ import com.LetMeDoWith.LetMeDoWith.application.task.service.UpdateDowithTaskServ
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponse;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponses;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiSuccessResponse;
+import com.LetMeDoWith.LetMeDoWith.common.dto.GenerateUploadPresignedUrlsResult;
 import com.LetMeDoWith.LetMeDoWith.common.dto.ResponseDto;
 import com.LetMeDoWith.LetMeDoWith.common.dto.ResponsePageDto;
 import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
@@ -22,7 +23,6 @@ import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -179,15 +179,12 @@ public class DowithTaskController {
 
         String memberId = AuthUtil.getMemberId();
 
-        List<String> presignedUrls = successDowithTaskService.generateDowithTaskSuccessImageUploadPresignedUrls(
-                memberId, dowithTaskId, requestBody.imageFileNames());
+        GenerateUploadPresignedUrlsResult result =
+                successDowithTaskService.generateDowithTaskSuccessImageUploadPresignedUrls(
+                        memberId, dowithTaskId, requestBody.imageFileNames());
 
-        List<String> publicImageUrls = presignedUrls.stream()
-                .map(url -> url.contains("?") ? url.substring(0, url.indexOf('?')) : url)
-                .toList();
-
-        return ResponseUtil.createSuccessResponse(
-                new GenerateDowithTaskSuccessImageUploadPresignedUrlsResDto(publicImageUrls, presignedUrls, "POST"));
+        return ResponseUtil.createSuccessResponse(new GenerateDowithTaskSuccessImageUploadPresignedUrlsResDto(
+                result.publicImageUrls(), result.presignedUrls(), result.method()));
     }
 
     @Operation(summary = "두윗모드 Task 인증", description = "Presigned url을 통해서 업로드한 파일의 public url을 body에 담아 요청합니다.")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -138,7 +138,7 @@ spring:
       on-profile: test
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/letmedowith_app
+    url: jdbc:mysql://localhost:3306/letmedowith_test
   data:
     redis:
       host: localhost
@@ -156,7 +156,7 @@ spring:
     baseline-on-migrate: true
     baseline-version: 1
     enabled: false
-    url: jdbc:mysql://localhost:3306/letmedowith_app
+    url: jdbc:mysql://localhost:3306/letmedowith_test
   batch:
     jdbc:
       initialize-schema: always   # 운영은 보통 'never'로 두고 DDL 미리 반영

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/common/service/PresignedUrlServiceTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/common/service/PresignedUrlServiceTest.java
@@ -1,0 +1,67 @@
+package com.LetMeDoWith.LetMeDoWith.common.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.LetMeDoWith.LetMeDoWith.common.dto.GenerateUploadPresignedUrlsResult;
+import com.LetMeDoWith.LetMeDoWith.common.enums.common.FileNamespace;
+import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PresignedUrlServiceTest {
+
+    @Mock
+    private FileClient fileClient;
+
+    @InjectMocks
+    private PresignedUrlService presignedUrlService;
+
+    @Test
+    @DisplayName("[SUCCESS] namespace와 파일명으로 presigned URL 응답을 생성한다.")
+    void generateUploadPresignedUrlsSuccess() {
+        when(fileClient.getUploadPresignedUrl(startsWith("dowith_task_confirms/"), any()))
+                .thenReturn(
+                        "https://bucket.s3.ap-northeast-2.amazonaws.com/dowith_task_confirms/00/test_photo1.jpg?signature=abc")
+                .thenReturn(
+                        "https://bucket.s3.ap-northeast-2.amazonaws.com/dowith_task_confirms/01/test_photo2.png?signature=def");
+
+        GenerateUploadPresignedUrlsResult result = presignedUrlService.generateUploadPresignedUrls(
+                FileNamespace.DOWITH_TASK_CONFIRM, List.of("photo1.jpg", "photo2.png"));
+
+        assertThat(result.method()).isEqualTo("POST");
+        assertThat(result.presignedUrls()).hasSize(2);
+        assertThat(result.publicImageUrls())
+                .containsExactly(
+                        "https://bucket.s3.ap-northeast-2.amazonaws.com/dowith_task_confirms/00/test_photo1.jpg",
+                        "https://bucket.s3.ap-northeast-2.amazonaws.com/dowith_task_confirms/01/test_photo2.png");
+        verify(fileClient, times(2)).getUploadPresignedUrl(startsWith("dowith_task_confirms/"), any());
+    }
+
+    @Test
+    @DisplayName("[FAIL] 허용되지 않은 확장자가 포함되면 예외가 발생한다.")
+    void generateUploadPresignedUrlsFailWhenInvalidExtension() {
+        assertThatThrownBy(() -> presignedUrlService.generateUploadPresignedUrls(
+                        FileNamespace.DOWITH_TASK_CONFIRM, List.of("photo1.pdf", "photo2.jpg")))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    @DisplayName("[FAIL] 빈 파일명 목록이면 예외가 발생한다.")
+    void generateUploadPresignedUrlsFailWhenEmptyFileNames() {
+        assertThatThrownBy(() ->
+                        presignedUrlService.generateUploadPresignedUrls(FileNamespace.DOWITH_TASK_CONFIRM, List.of()))
+                .isInstanceOf(RestApiException.class);
+    }
+}

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/member/MemberProfileImagePresignedUrlIntegrationTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/member/MemberProfileImagePresignedUrlIntegrationTest.java
@@ -1,15 +1,13 @@
 package com.LetMeDoWith.LetMeDoWith.integration.member;
 
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.LetMeDoWith.LetMeDoWith.infrastructure.member.persistence.jpaRepository.MemberJpaRepository;
 import com.LetMeDoWith.LetMeDoWith.integration.AbstractIntegrationTest;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.GenerateMemberProfileImageUploadPresignedUrlReqDto;
-import org.hamcrest.Matchers;
+import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.GenerateMemberProfileImageUploadPresignedUrlResDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -18,9 +16,6 @@ public class MemberProfileImagePresignedUrlIntegrationTest extends AbstractInteg
 
     private static final String GENERATE_MEMBER_PROFILE_IMAGE_UPLOAD_PRESIGNED_URL =
             "/api/v1/members/profile-image/upload-presigned-url";
-
-    @Autowired
-    private MemberJpaRepository memberJpaRepository;
 
     @Value("${cloud.aws.s3.bucketName}")
     private String bucketName;
@@ -45,15 +40,16 @@ public class MemberProfileImagePresignedUrlIntegrationTest extends AbstractInteg
         ResultActions resultActions =
                 this.request(MockMvcRequestBuilders.post(GENERATE_MEMBER_PROFILE_IMAGE_UPLOAD_PRESIGNED_URL)
                         .content(this.writeRequestBodyAsString(requestBody)));
+        GenerateMemberProfileImageUploadPresignedUrlResDto response =
+                this.readResponse(resultActions, GenerateMemberProfileImageUploadPresignedUrlResDto.class);
 
         String presignedUrlPrefix = String.format("https://%s.s3.%s.amazonaws.com/member_profiles", bucketName, region);
 
-        resultActions
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.presignedUrl").value(Matchers.containsString("profile.png")))
-                .andExpect(jsonPath("$.data.presignedUrl").value(Matchers.containsString(presignedUrlPrefix)))
-                .andExpect(jsonPath("$.data.publicImageUrl").value(Matchers.containsString("profile.png")))
-                .andExpect(jsonPath("$.data.method").value("POST"));
+        resultActions.andExpect(status().isOk());
+        assertThat(response.presignedUrl()).contains("profile.png");
+        assertThat(response.presignedUrl()).contains(presignedUrlPrefix);
+        assertThat(response.publicImageUrl()).contains("profile.png");
+        assertThat(response.method()).isEqualTo("POST");
     }
 
     @Test

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/member/MemberProfileImagePresignedUrlIntegrationTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/member/MemberProfileImagePresignedUrlIntegrationTest.java
@@ -1,0 +1,71 @@
+package com.LetMeDoWith.LetMeDoWith.integration.member;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.LetMeDoWith.LetMeDoWith.infrastructure.member.persistence.jpaRepository.MemberJpaRepository;
+import com.LetMeDoWith.LetMeDoWith.integration.AbstractIntegrationTest;
+import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.GenerateMemberProfileImageUploadPresignedUrlReqDto;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class MemberProfileImagePresignedUrlIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String GENERATE_MEMBER_PROFILE_IMAGE_UPLOAD_PRESIGNED_URL =
+            "/api/v1/members/profile-image/upload-presigned-url";
+
+    @Autowired
+    private MemberJpaRepository memberJpaRepository;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+
+    @Value("${cloud.aws.region}")
+    private String region;
+
+    @Override
+    protected void deleteTestData() {
+        // requestMember cleanup is handled by AbstractIntegrationTest
+    }
+
+    @Override
+    protected void createTestData() {}
+
+    @Test
+    @DisplayName("[SUCCESS] 회원 프로필 이미지 업로드 presigned URL 발급")
+    void generateMemberProfileImageUploadPresignedUrl() throws Exception {
+        GenerateMemberProfileImageUploadPresignedUrlReqDto requestBody =
+                new GenerateMemberProfileImageUploadPresignedUrlReqDto("profile.png");
+
+        ResultActions resultActions =
+                this.request(MockMvcRequestBuilders.post(GENERATE_MEMBER_PROFILE_IMAGE_UPLOAD_PRESIGNED_URL)
+                        .content(this.writeRequestBodyAsString(requestBody)));
+
+        String presignedUrlPrefix = String.format("https://%s.s3.%s.amazonaws.com/member_profiles", bucketName, region);
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.presignedUrl").value(Matchers.containsString("profile.png")))
+                .andExpect(jsonPath("$.data.presignedUrl").value(Matchers.containsString(presignedUrlPrefix)))
+                .andExpect(jsonPath("$.data.publicImageUrl").value(Matchers.containsString("profile.png")))
+                .andExpect(jsonPath("$.data.method").value("POST"));
+    }
+
+    @Test
+    @DisplayName("[FAIL] 허용되지 않은 프로필 이미지 확장자인 경우")
+    void generateMemberProfileImageUploadPresignedUrlFail() throws Exception {
+        GenerateMemberProfileImageUploadPresignedUrlReqDto requestBody =
+                new GenerateMemberProfileImageUploadPresignedUrlReqDto("profile.pdf");
+
+        ResultActions resultActions =
+                this.request(MockMvcRequestBuilders.post(GENERATE_MEMBER_PROFILE_IMAGE_UPLOAD_PRESIGNED_URL)
+                        .content(this.writeRequestBodyAsString(requestBody)));
+
+        resultActions.andExpect(status().is4xxClientError());
+    }
+}


### PR DESCRIPTION
## PR 체크리스트

Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [x] 모든 Test 코드를 실행하여 PASS했나요?
- [x] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

PR의 타입을 체크해주세요

- [ ] 버그 픽스 - 이슈 링크 :
- [x] 신규 기능 개발
- [ ] 기능 수정
- [x] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [x] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타

## 백로그 및 이슈 링크

- 링크 : [`TAS-557`](https://www.notion.so/Presigned-URL-API-Member-Profile-Image-API-2f2df3a3e43f80cbb6bacc60d3a1a990?v=72865a96132e456c873537e8de4c3757&source=copy_link)

## 변경된 사항

### Presigned URL 발급 공통화

- S3 업로드용 presigned URL 발급 로직을 `common` 계층의 `PresignedUrlService`로 공통화했습니다.
- `dowith` 성공 인증 이미지 발급 로직은 도메인 검증만 남기고, key 생성 및 presigned URL 발급은 공통 서비스에 위임하도록 정리했습니다.

### 회원 프로필 이미지 Presigned URL API 추가

- 회원 프로필 이미지 업로드를 위한 presigned URL 발급 API `POST /api/v1/members/profile-image/upload-presigned-url` 를 추가했습니다.
- `member_profiles/` namespace를 도입하고, member 도메인에서 프로필 이미지 업로드 전에 단일 이미지용 presigned/public URL을 발급받을 수 있도록 연결했습니다.


### 테스트 및 검증 보강

- 공통 presigned URL 서비스 단위 테스트와 회원 프로필 이미지 presigned URL 통합 테스트를 추가했습니다.
- 파일 key timestamp 포맷을 `yyyyMMddHHmmssZ` 형태로 수정하고, 실제 서버 기동 환경에서 `dowith`/`member` 발급 API 동작도 확인했습니다.

## 기타 전달 사항

### 도메인별 API로 노출한 이유

- presigned URL 발급 로직 자체는 공통화했지만, 외부 API는 `dowith`, `member` 등 각 도메인 컨트롤러에서 노출하도록 유지했습니다.
- 공통 API로 직접 `namespace`를 받는 구조로 열면 프론트엔드가 백엔드 내부 저장 정책과 namespace 규칙을 알아야 해서 결합도가 높아집니다.
- 도메인별 API를 유지하면 프론트엔드는 기능 단위 엔드포인트만 알면 되고, 실제 S3 prefix 정책과 업로드 규칙은 백엔드 내부에서 캡슐화할 수 있습니다.
- 또한 각 도메인별 비즈니스 로직과 권한 검증을 자연스럽게 유지할 수 있어, 공통 구현과 책임을 분리하면서도 API스펙은 단순하게 가져갈 수 있습니다.
