### PR TITLE
[TAS-668] 보낸/받은 잔소리 조회 응답 DTO 분리 및 쿼리 개선

### DIFF
--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveReceivedTaskFeedbackResult.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveReceivedTaskFeedbackResult.java
@@ -1,0 +1,42 @@
+package com.LetMeDoWith.LetMeDoWith.application.feedback.dto;
+
+import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.DowithTaskFeedbackQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.TaskFeedbackTemplateQueryDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "받은 잔소리 조회 결과")
+public record RetrieveReceivedTaskFeedbackResult(Long totalCount, List<ReceivedTaskFeedbackDto> feedbacks) {
+
+    public static RetrieveReceivedTaskFeedbackResult of(
+            Long totalCount, List<DowithTaskFeedbackQueryDto> feedbacks, List<TaskFeedbackTemplateQueryDto> templates) {
+        List<ReceivedTaskFeedbackDto> feedbackDtos = feedbacks.stream()
+                .map(feedback -> new ReceivedTaskFeedbackDto(
+                        feedback.id(),
+                        feedback.dowithTaskId(),
+                        feedback.senderId(),
+                        feedback.senderNickname(),
+                        feedback.senderProfileImageUrl(),
+                        feedback.isChecked(),
+                        feedback.receivedAt(),
+                        RetrieveTaskFeedbackResult.TaskFeedbackTemplateDto.from(templates.stream()
+                                .filter(template -> template.id().equals(feedback.taskFeedbackTemplateId()))
+                                .findFirst()
+                                .get())))
+                .toList();
+
+        return new RetrieveReceivedTaskFeedbackResult(totalCount, feedbackDtos);
+    }
+
+    public record ReceivedTaskFeedbackDto(
+            @Schema(description = "잔소리 ID", example = "1") Long id,
+            @Schema(description = "두윗모드 Task ID", example = "12345") Long dowithTaskId,
+            @Schema(description = "잔소리 보낸사람 ID", example = "(TSID)") String senderId,
+            @Schema(description = "잔소리 보낸사람 닉네임", example = "feedbackSender123") String senderNickname,
+            @Schema(description = "잔소리 보낸사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+                    String senderProfileImageUrl,
+            @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
+            @Schema(description = "잔소리 받은 시각") LocalDateTime receivedAt,
+            @Schema(description = "잔소리 템플릿") RetrieveTaskFeedbackResult.TaskFeedbackTemplateDto taskFeedbackTemplate) {}
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveSentTaskFeedbackResult.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveSentTaskFeedbackResult.java
@@ -1,0 +1,44 @@
+package com.LetMeDoWith.LetMeDoWith.application.feedback.dto;
+
+import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.SentDowithTaskFeedbackQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.TaskFeedbackTemplateQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.enums.DowithTaskStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "보낸 잔소리 조회 결과")
+public record RetrieveSentTaskFeedbackResult(Long totalCount, List<SentTaskFeedbackDto> feedbacks) {
+
+    public static RetrieveSentTaskFeedbackResult of(
+            Long totalCount,
+            List<SentDowithTaskFeedbackQueryDto> feedbacks,
+            List<TaskFeedbackTemplateQueryDto> templates) {
+        List<SentTaskFeedbackDto> feedbackDtos = feedbacks.stream()
+                .map(feedback -> new SentTaskFeedbackDto(
+                        feedback.id(),
+                        feedback.dowithTaskId(),
+                        feedback.senderId(),
+                        feedback.senderNickname(),
+                        feedback.senderProfileImageUrl(),
+                        feedback.isChecked(),
+                        feedback.dowithTaskStatus(),
+                        RetrieveTaskFeedbackResult.TaskFeedbackTemplateDto.from(templates.stream()
+                                .filter(template -> template.id().equals(feedback.taskFeedbackTemplateId()))
+                                .findFirst()
+                                .get())))
+                .toList();
+
+        return new RetrieveSentTaskFeedbackResult(totalCount, feedbackDtos);
+    }
+
+    public record SentTaskFeedbackDto(
+            @Schema(description = "잔소리 ID", example = "1") Long id,
+            @Schema(description = "두윗모드 Task ID", example = "12345") Long dowithTaskId,
+            @Schema(description = "잔소리 보낸사람 ID", example = "(TSID)") String senderId,
+            @Schema(description = "잔소리 보낸사람 닉네임", example = "feedbackSender123") String senderNickname,
+            @Schema(description = "잔소리 보낸사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+                    String senderProfileImageUrl,
+            @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
+            @Schema(description = "잔소리 대상 두윗모드 Task 상태", example = "WAIT") DowithTaskStatus dowithTaskStatus,
+            @Schema(description = "잔소리 템플릿") RetrieveTaskFeedbackResult.TaskFeedbackTemplateDto taskFeedbackTemplate) {}
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/service/RetrieveTaskFeedbackService.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/service/RetrieveTaskFeedbackService.java
@@ -1,11 +1,14 @@
 package com.LetMeDoWith.LetMeDoWith.application.feedback.service;
 
+import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveReceivedTaskFeedbackResult;
+import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveSentTaskFeedbackResult;
 import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveTaskFeedbackResult;
 import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveTaskFeedbackTemplatesResult;
 import com.LetMeDoWith.LetMeDoWith.common.util.AuthUtil;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.DowithTaskFeedbackQueryRepository;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.TaskFeedbackTemplateQueryRepository;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.DowithTaskFeedbackQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.SentDowithTaskFeedbackQueryDto;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.TaskFeedbackTemplateQueryDto;
 import com.LetMeDoWith.LetMeDoWith.domain.task.enums.CountryCode;
 import java.util.List;
@@ -42,18 +45,17 @@ public class RetrieveTaskFeedbackService {
      *
      * @return
      */
-    public RetrieveTaskFeedbackResult retrieveSendFeedbacks(Pageable pageable) {
+    public RetrieveSentTaskFeedbackResult retrieveSendFeedbacks(Pageable pageable) {
 
         String memberId = AuthUtil.getMemberId();
-        CountryCode countryCode = CountryCode.KR;
 
         Long totalCount = dowithTaskFeedbackQueryRepository.countFeedbacksBySenderId(memberId);
-        List<DowithTaskFeedbackQueryDto> feedbackDtos = dowithTaskFeedbackQueryRepository.getFeedbacksBySenderId(
+        List<SentDowithTaskFeedbackQueryDto> feedbackDtos = dowithTaskFeedbackQueryRepository.getFeedbacksBySenderId(
                 memberId, pageable.getOffset(), pageable.getPageSize());
         List<TaskFeedbackTemplateQueryDto> feedbackTemplates =
-                taskFeedbackTemplateQueryRepository.getAllTaskFeedbackTemplates(countryCode);
+                taskFeedbackTemplateQueryRepository.getAllTaskFeedbackTemplates(CountryCode.KR);
 
-        return RetrieveTaskFeedbackResult.of(totalCount, feedbackDtos, feedbackTemplates);
+        return RetrieveSentTaskFeedbackResult.of(totalCount, feedbackDtos, feedbackTemplates);
     }
 
     /**
@@ -61,18 +63,17 @@ public class RetrieveTaskFeedbackService {
      *
      * @return
      */
-    public RetrieveTaskFeedbackResult retrieveReceivedFeedbacks(Pageable pageable) {
+    public RetrieveReceivedTaskFeedbackResult retrieveReceivedFeedbacks(Pageable pageable) {
 
         String memberId = AuthUtil.getMemberId();
-        CountryCode countryCode = CountryCode.KR;
 
         Long totalCount = dowithTaskFeedbackQueryRepository.countFeedbacksByReceiverId(memberId);
         List<DowithTaskFeedbackQueryDto> feedbackDtos = dowithTaskFeedbackQueryRepository.getFeedbacksByReceiverId(
                 memberId, pageable.getOffset(), pageable.getPageSize());
         List<TaskFeedbackTemplateQueryDto> feedbackTemplates =
-                taskFeedbackTemplateQueryRepository.getAllTaskFeedbackTemplates(countryCode);
+                taskFeedbackTemplateQueryRepository.getAllTaskFeedbackTemplates(CountryCode.KR);
 
-        return RetrieveTaskFeedbackResult.of(totalCount, feedbackDtos, feedbackTemplates);
+        return RetrieveReceivedTaskFeedbackResult.of(totalCount, feedbackDtos, feedbackTemplates);
     }
 
     /**

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/feedback/repository/DowithTaskFeedbackQueryRepository.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/feedback/repository/DowithTaskFeedbackQueryRepository.java
@@ -3,6 +3,7 @@ package com.LetMeDoWith.LetMeDoWith.domain.feedback.repository;
 import com.LetMeDoWith.LetMeDoWith.common.enums.common.SortDirection;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.CountSentFeedback;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.DowithTaskFeedbackQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.SentDowithTaskFeedbackQueryDto;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.SentFeedbacksQueryDto;
 import java.time.LocalDate;
 import java.util.List;
@@ -16,7 +17,7 @@ public interface DowithTaskFeedbackQueryRepository {
 
     Long countFeedbacksBySenderId(String senderId);
 
-    List<DowithTaskFeedbackQueryDto> getFeedbacksBySenderId(String senderId, Long offset, int limit);
+    List<SentDowithTaskFeedbackQueryDto> getFeedbacksBySenderId(String senderId, Long offset, int limit);
 
     Long countFeedbacksByReceiverId(String receiverId);
 

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/feedback/repository/dto/SentDowithTaskFeedbackQueryDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/feedback/repository/dto/SentDowithTaskFeedbackQueryDto.java
@@ -1,16 +1,16 @@
 package com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto;
 
+import com.LetMeDoWith.LetMeDoWith.domain.task.enums.DowithTaskStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 
-@Schema(description = "두윗모드 Task 잔소리 조회 DTO")
-public record DowithTaskFeedbackQueryDto(
+@Schema(description = "보낸 잔소리 조회 DTO")
+public record SentDowithTaskFeedbackQueryDto(
         @Schema(description = "잔소리 ID", example = "1") Long id,
         @Schema(description = "두윗모드 Task ID", example = "12345") Long dowithTaskId,
         @Schema(description = "잔소리 템플릿 ID", example = "67890") Long taskFeedbackTemplateId,
         @Schema(description = "잔소리 보낸사람 ID", example = "(TSID)") String senderId,
-        @Schema(description = "잔소리 받는사람 닉네임", example = "feedbackSender123") String senderNickname,
-        @Schema(description = "잔소리 받는사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        @Schema(description = "잔소리 보낸사람 닉네임", example = "feedbackSender123") String senderNickname,
+        @Schema(description = "잔소리 보낸사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
                 String senderProfileImageUrl,
         @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
-        @Schema(description = "잔소리 받은 시각") LocalDateTime receivedAt) {}
+        @Schema(description = "잔소리 대상 두윗모드 Task 상태", example = "WAIT") DowithTaskStatus dowithTaskStatus) {}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/auth/client/AppleAuthClient.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/auth/client/AppleAuthClient.java
@@ -11,7 +11,7 @@ import reactor.core.publisher.Mono;
 
 @Component
 @RequiredArgsConstructor
-//@Profile("!dev")
+// @Profile("!dev")
 public class AppleAuthClient implements AuthClient {
 
     private final WebClient webClient;

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/auth/client/GoogleAuthClient.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/auth/client/GoogleAuthClient.java
@@ -13,7 +13,7 @@ import reactor.core.publisher.Mono;
 
 @Component
 @RequiredArgsConstructor
-//@Profile("!dev")
+// @Profile("!dev")
 @CacheConfig(cacheNames = CacheName.GOOGLE_PUBLIC_KEY)
 public class GoogleAuthClient implements AuthClient {
 

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/feedback/query/DowithTaskFeedbackQueryRepositoryImpl.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/feedback/query/DowithTaskFeedbackQueryRepositoryImpl.java
@@ -6,8 +6,10 @@ import com.LetMeDoWith.LetMeDoWith.domain.feedback.model.QDowithTaskFeedback;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.DowithTaskFeedbackQueryRepository;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.CountSentFeedback;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.DowithTaskFeedbackQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.SentDowithTaskFeedbackQueryDto;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.SentFeedbacksQueryDto;
 import com.LetMeDoWith.LetMeDoWith.domain.member.model.QMember;
+import com.LetMeDoWith.LetMeDoWith.domain.task.model.QDowithTask;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.OrderSpecifier;
@@ -31,6 +33,7 @@ public class DowithTaskFeedbackQueryRepositoryImpl implements DowithTaskFeedback
     private final JPAQueryFactory queryFactory;
     private final QDowithTaskFeedback dowithTaskFeedback = QDowithTaskFeedback.dowithTaskFeedback;
     private final QMember member = QMember.member;
+    private final QDowithTask dowithTask = QDowithTask.dowithTask;
 
     @Override
     public Long countFeedbacksByTaskId(Long taskId) {
@@ -53,13 +56,12 @@ public class DowithTaskFeedbackQueryRepositoryImpl implements DowithTaskFeedback
                         member.nickname,
                         member.profileImageUrl,
                         new CaseBuilder()
-                                .when(dowithTaskFeedback.isChecked.eq(
-                                        com.LetMeDoWith.LetMeDoWith.common.enums.common.Yn.TRUE))
+                                .when(dowithTaskFeedback.isChecked.eq(Yn.TRUE))
                                 .then(true)
-                                .otherwise(false)))
+                                .otherwise(false),
+                        dowithTaskFeedback.createdAt))
                 .from(dowithTaskFeedback)
                 .leftJoin(member)
-                .fetchJoin()
                 .on(dowithTaskFeedback.senderMemberId.eq(member.id))
                 .where(dowithTaskFeedback.dowithTaskId.eq(taskId))
                 .orderBy(dowithTaskFeedback.createdAt.desc())
@@ -78,10 +80,10 @@ public class DowithTaskFeedbackQueryRepositoryImpl implements DowithTaskFeedback
     }
 
     @Override
-    public List<DowithTaskFeedbackQueryDto> getFeedbacksBySenderId(String senderId, Long offset, int size) {
+    public List<SentDowithTaskFeedbackQueryDto> getFeedbacksBySenderId(String senderId, Long offset, int size) {
         return queryFactory
                 .select(Projections.constructor(
-                        DowithTaskFeedbackQueryDto.class,
+                        SentDowithTaskFeedbackQueryDto.class,
                         dowithTaskFeedback.id,
                         dowithTaskFeedback.dowithTaskId,
                         dowithTaskFeedback.taskFeedbackTemplateId,
@@ -91,11 +93,13 @@ public class DowithTaskFeedbackQueryRepositoryImpl implements DowithTaskFeedback
                         new CaseBuilder()
                                 .when(dowithTaskFeedback.isChecked.eq(Yn.TRUE))
                                 .then(true)
-                                .otherwise(false)))
+                                .otherwise(false),
+                        dowithTask.status))
                 .from(dowithTaskFeedback)
                 .leftJoin(member)
-                .fetchJoin()
                 .on(dowithTaskFeedback.senderMemberId.eq(member.id))
+                .leftJoin(dowithTask)
+                .on(dowithTaskFeedback.dowithTaskId.eq(dowithTask.id))
                 .where(dowithTaskFeedback.senderMemberId.eq(senderId))
                 .orderBy(dowithTaskFeedback.createdAt.desc())
                 .offset(offset)
@@ -126,10 +130,10 @@ public class DowithTaskFeedbackQueryRepositoryImpl implements DowithTaskFeedback
                         new CaseBuilder()
                                 .when(dowithTaskFeedback.isChecked.eq(Yn.TRUE))
                                 .then(true)
-                                .otherwise(false)))
+                                .otherwise(false),
+                        dowithTaskFeedback.createdAt))
                 .from(dowithTaskFeedback)
                 .leftJoin(member)
-                .fetchJoin()
                 .on(dowithTaskFeedback.senderMemberId.eq(member.id))
                 .where(dowithTaskFeedback.receiverMemberId.eq(receiverId))
                 .orderBy(dowithTaskFeedback.createdAt.desc())

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/controller/DowithTaskFeedbackController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/controller/DowithTaskFeedbackController.java
@@ -1,5 +1,7 @@
 package com.LetMeDoWith.LetMeDoWith.presentation.feedback.controller;
 
+import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveReceivedTaskFeedbackResult;
+import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveSentTaskFeedbackResult;
 import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveTaskFeedbackResult;
 import com.LetMeDoWith.LetMeDoWith.application.feedback.service.CreateDowithTaskFeedbackService;
 import com.LetMeDoWith.LetMeDoWith.application.feedback.service.RetrieveTaskFeedbackService;
@@ -15,6 +17,8 @@ import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
 import com.LetMeDoWith.LetMeDoWith.domain.task.enums.CountryCode;
 import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.CreateDowithFeedbackReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.RetrieveDowithTaskFeedbacksResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.RetrieveReceivedDowithTaskFeedbacksResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.RetrieveSentDowithTaskFeedbacksResDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.RetrieveTaskFeedbackTemplatesResDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -68,26 +72,28 @@ public class DowithTaskFeedbackController {
                 RetrieveDowithTaskFeedbacksResDto.from(result), pageable, result.totalCount());
     }
 
-    @Operation(summary = "보낸 잔소리 조회", description = "유져가 보낸 잔소리 목록을 조회합니다.")
+    @Operation(
+            summary = "보낸 잔소리 조회",
+            description = "유저가 보낸 잔소리 목록을 조회합니다. 잔소리 대상 두윗모드 Task의 상태(dowithTaskStatus)를 포함합니다.")
     @ApiSuccessResponse(description = "보낸 잔소리 목록 조회 성공.")
     @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST)})
     @GetMapping("/send")
-    public ResponseEntity<ResponsePageDto<RetrieveDowithTaskFeedbacksResDto>> retrieveSendFeedbacks(
+    public ResponseEntity<ResponsePageDto<RetrieveSentDowithTaskFeedbacksResDto>> retrieveSendFeedbacks(
             @ParameterObject Pageable pageable) {
-        RetrieveTaskFeedbackResult result = retrieveTaskFeedbackService.retrieveSendFeedbacks(pageable);
+        RetrieveSentTaskFeedbackResult result = retrieveTaskFeedbackService.retrieveSendFeedbacks(pageable);
         return ResponseUtil.createSuccessResponse(
-                RetrieveDowithTaskFeedbacksResDto.from(result), pageable, result.totalCount());
+                RetrieveSentDowithTaskFeedbacksResDto.from(result), pageable, result.totalCount());
     }
 
-    @Operation(summary = "받은 잔소리 조회", description = "유져가 받은 잔소리 목록을 조회합니다.")
+    @Operation(summary = "받은 잔소리 조회", description = "유저가 받은 잔소리 목록을 조회합니다. 잔소리를 받은 시각(receivedAt)을 포함합니다.")
     @ApiSuccessResponse(description = "받은 잔소리 목록 조회 성공")
     @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST)})
     @GetMapping("/received")
-    public ResponseEntity<ResponsePageDto<RetrieveDowithTaskFeedbacksResDto>> retrieveReceivedFeedbacks(
+    public ResponseEntity<ResponsePageDto<RetrieveReceivedDowithTaskFeedbacksResDto>> retrieveReceivedFeedbacks(
             @ParameterObject Pageable pageable) {
-        RetrieveTaskFeedbackResult result = retrieveTaskFeedbackService.retrieveReceivedFeedbacks(pageable);
+        RetrieveReceivedTaskFeedbackResult result = retrieveTaskFeedbackService.retrieveReceivedFeedbacks(pageable);
         return ResponseUtil.createSuccessResponse(
-                RetrieveDowithTaskFeedbacksResDto.from(result), pageable, result.totalCount());
+                RetrieveReceivedDowithTaskFeedbacksResDto.from(result), pageable, result.totalCount());
     }
 
     @Operation(summary = "잔소리 템플릿 목록 조회", description = "국가 코드(CountryCode)에 따라 잔소리 템플릿 목록을 조회합니다.")

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveReceivedDowithTaskFeedbacksResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveReceivedDowithTaskFeedbacksResDto.java
@@ -1,0 +1,55 @@
+package com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto;
+
+import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveReceivedTaskFeedbackResult;
+import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveReceivedTaskFeedbackResult.ReceivedTaskFeedbackDto;
+import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveTaskFeedbackResult.TaskFeedbackTemplateDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.enums.CountryCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "받은 잔소리 목록 조회 응답")
+public record RetrieveReceivedDowithTaskFeedbacksResDto(
+        @Schema(description = "받은 잔소리 목록") List<ReceivedFeedbackDto> feedbacks) {
+
+    public static RetrieveReceivedDowithTaskFeedbacksResDto from(RetrieveReceivedTaskFeedbackResult result) {
+        return new RetrieveReceivedDowithTaskFeedbacksResDto(
+                result.feedbacks().stream().map(ReceivedFeedbackDto::from).toList());
+    }
+
+    public record ReceivedFeedbackDto(
+            @Schema(description = "잔소리 ID", example = "1") Long id,
+            @Schema(description = "두윗모드 Task ID", example = "12345") Long dowithTaskId,
+            @Schema(description = "잔소리 보낸사람 ID", example = "(TSID)") String senderId,
+            @Schema(description = "잔소리 보낸사람 닉네임", example = "feedbackSender123") String senderNickname,
+            @Schema(description = "잔소리 보낸사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+                    String senderProfileImageUrl,
+            @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
+            @Schema(description = "잔소리 받은 시각") LocalDateTime receivedAt,
+            @Schema(description = "잔소리 템플릿") ReceivedFeedbackTemplateDto taskFeedbackTemplate) {
+
+        public static ReceivedFeedbackDto from(ReceivedTaskFeedbackDto feedback) {
+            return new ReceivedFeedbackDto(
+                    feedback.id(),
+                    feedback.dowithTaskId(),
+                    feedback.senderId(),
+                    feedback.senderNickname(),
+                    feedback.senderProfileImageUrl(),
+                    feedback.isChecked(),
+                    feedback.receivedAt(),
+                    ReceivedFeedbackTemplateDto.from(feedback.taskFeedbackTemplate()));
+        }
+    }
+
+    public record ReceivedFeedbackTemplateDto(
+            @Schema(description = "잔소리 템플릿 ID", example = "1") Long id,
+            @Schema(description = "잔소리 템플릿 언어", example = "ko") CountryCode language,
+            @Schema(description = "잔소리 템플릿 메시지", example = "잔소리 템플릿 메시지") String message,
+            @Schema(description = "잔소리 템플릿 이모지 URL", example = "https://example.com/emoji.png") String emojiUrl) {
+
+        public static ReceivedFeedbackTemplateDto from(TaskFeedbackTemplateDto template) {
+            return new ReceivedFeedbackTemplateDto(
+                    template.id(), template.language(), template.message(), template.emojiUrl());
+        }
+    }
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveSentDowithTaskFeedbacksResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveSentDowithTaskFeedbacksResDto.java
@@ -1,0 +1,55 @@
+package com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto;
+
+import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveSentTaskFeedbackResult;
+import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveSentTaskFeedbackResult.SentTaskFeedbackDto;
+import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.RetrieveTaskFeedbackResult.TaskFeedbackTemplateDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.enums.CountryCode;
+import com.LetMeDoWith.LetMeDoWith.domain.task.enums.DowithTaskStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "보낸 잔소리 목록 조회 응답")
+public record RetrieveSentDowithTaskFeedbacksResDto(
+        @Schema(description = "보낸 잔소리 목록") List<SentFeedbackDto> feedbacks) {
+
+    public static RetrieveSentDowithTaskFeedbacksResDto from(RetrieveSentTaskFeedbackResult result) {
+        return new RetrieveSentDowithTaskFeedbacksResDto(
+                result.feedbacks().stream().map(SentFeedbackDto::from).toList());
+    }
+
+    public record SentFeedbackDto(
+            @Schema(description = "잔소리 ID", example = "1") Long id,
+            @Schema(description = "두윗모드 Task ID", example = "12345") Long dowithTaskId,
+            @Schema(description = "잔소리 보낸사람 ID", example = "(TSID)") String senderId,
+            @Schema(description = "잔소리 보낸사람 닉네임", example = "feedbackSender123") String senderNickname,
+            @Schema(description = "잔소리 보낸사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+                    String senderProfileImageUrl,
+            @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
+            @Schema(description = "잔소리 대상 두윗모드 Task 상태", example = "WAIT") DowithTaskStatus dowithTaskStatus,
+            @Schema(description = "잔소리 템플릿") SentFeedbackTemplateDto taskFeedbackTemplate) {
+
+        public static SentFeedbackDto from(SentTaskFeedbackDto feedback) {
+            return new SentFeedbackDto(
+                    feedback.id(),
+                    feedback.dowithTaskId(),
+                    feedback.senderId(),
+                    feedback.senderNickname(),
+                    feedback.senderProfileImageUrl(),
+                    feedback.isChecked(),
+                    feedback.dowithTaskStatus(),
+                    SentFeedbackTemplateDto.from(feedback.taskFeedbackTemplate()));
+        }
+    }
+
+    public record SentFeedbackTemplateDto(
+            @Schema(description = "잔소리 템플릿 ID", example = "1") Long id,
+            @Schema(description = "잔소리 템플릿 언어", example = "ko") CountryCode language,
+            @Schema(description = "잔소리 템플릿 메시지", example = "잔소리 템플릿 메시지") String message,
+            @Schema(description = "잔소리 템플릿 이모지 URL", example = "https://example.com/emoji.png") String emojiUrl) {
+
+        public static SentFeedbackTemplateDto from(TaskFeedbackTemplateDto template) {
+            return new SentFeedbackTemplateDto(
+                    template.id(), template.language(), template.message(), template.emojiUrl());
+        }
+    }
+}

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/feedback/FeedbackIntegrationTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/feedback/FeedbackIntegrationTest.java
@@ -7,6 +7,7 @@ import com.LetMeDoWith.LetMeDoWith.common.enums.common.Yn;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.model.TaskFeedbackTemplate;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.model.TaskFeedbackTemplateMessage;
 import com.LetMeDoWith.LetMeDoWith.domain.task.enums.CountryCode;
+import com.LetMeDoWith.LetMeDoWith.domain.task.enums.DowithTaskStatus;
 import com.LetMeDoWith.LetMeDoWith.domain.task.model.DowithTask;
 import com.LetMeDoWith.LetMeDoWith.infrastructure.feedback.persistence.jpaRepository.DowithTaskFeedbackJpaRepository;
 import com.LetMeDoWith.LetMeDoWith.infrastructure.feedback.persistence.jpaRepository.TaskFeedbackTemplateJpaRepository;
@@ -16,6 +17,10 @@ import com.LetMeDoWith.LetMeDoWith.integration.AbstractIntegrationTest;
 import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.CreateDowithFeedbackReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.RetrieveDowithTaskFeedbacksResDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.RetrieveDowithTaskFeedbacksResDto.RetrieveTaskFeedbackDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.RetrieveReceivedDowithTaskFeedbacksResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.RetrieveReceivedDowithTaskFeedbacksResDto.ReceivedFeedbackDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.RetrieveSentDowithTaskFeedbacksResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto.RetrieveSentDowithTaskFeedbacksResDto.SentFeedbackDto;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -142,6 +147,48 @@ public class FeedbackIntegrationTest extends AbstractIntegrationTest {
         assertThat(result.feedbacks()).isNotEmpty();
         RetrieveTaskFeedbackDto feedback = result.feedbacks().get(0);
         assertThat(feedback.dowithTaskId()).isEqualTo(dowithTask.getId());
+        assertThat(feedback.taskFeedbackTemplate().id()).isEqualTo(template1.getId());
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 보낸 잔소리 조회 - dowithTaskStatus 포함")
+    void retrieveSentFeedbacks_success() throws Exception {
+        this.request(MockMvcRequestBuilders.post("/api/v1/feedbacks")
+                        .content(writeRequestBodyAsString(
+                                new CreateDowithFeedbackReqDto(dowithTask.getId(), template1.getId()))))
+                .andExpect(status().isOk());
+
+        MvcResult retrieveResult = this.request(MockMvcRequestBuilders.get("/api/v1/feedbacks/send"))
+                .andExpect(status().isOk())
+                .andReturn();
+        RetrieveSentDowithTaskFeedbacksResDto result = this.readPagingResponse(
+                retrieveResult.getResponse().getContentAsString(), RetrieveSentDowithTaskFeedbacksResDto.class);
+
+        assertThat(result.feedbacks()).isNotEmpty();
+        SentFeedbackDto feedback = result.feedbacks().get(0);
+        assertThat(feedback.dowithTaskId()).isEqualTo(dowithTask.getId());
+        assertThat(feedback.dowithTaskStatus()).isEqualTo(DowithTaskStatus.WAIT);
+        assertThat(feedback.taskFeedbackTemplate().id()).isEqualTo(template1.getId());
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 받은 잔소리 조회 - receivedAt 포함")
+    void retrieveReceivedFeedbacks_success() throws Exception {
+        this.request(MockMvcRequestBuilders.post("/api/v1/feedbacks")
+                        .content(writeRequestBodyAsString(
+                                new CreateDowithFeedbackReqDto(dowithTask.getId(), template1.getId()))))
+                .andExpect(status().isOk());
+
+        MvcResult retrieveResult = this.request(MockMvcRequestBuilders.get("/api/v1/feedbacks/received"))
+                .andExpect(status().isOk())
+                .andReturn();
+        RetrieveReceivedDowithTaskFeedbacksResDto result = this.readPagingResponse(
+                retrieveResult.getResponse().getContentAsString(), RetrieveReceivedDowithTaskFeedbacksResDto.class);
+
+        assertThat(result.feedbacks()).isNotEmpty();
+        ReceivedFeedbackDto feedback = result.feedbacks().get(0);
+        assertThat(feedback.dowithTaskId()).isEqualTo(dowithTask.getId());
+        assertThat(feedback.receivedAt()).isNotNull();
         assertThat(feedback.taskFeedbackTemplate().id()).isEqualTo(template1.getId());
     }
 


### PR DESCRIPTION
## PR 체크리스트

Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [x] 모든 Test 코드를 실행하여 PASS했나요?
- [x] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

PR의 타입을 체크해주세요

- [ ] 버그 픽스 - 이슈 링크 :
- [ ] 신규 기능 개발
- [ ] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [x] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타

## 백로그 및 이슈 링크

- 링크 : TAS-668

## 변경된 사항

### 보낸/받은 잔소리 응답 DTO 분리

- `RetrieveSentTaskFeedbackResult` / `RetrieveReceivedTaskFeedbackResult` 로 응답 타입 분리
- 보낸 잔소리 응답에 잔소리 대상 두윗 Task의 상태(`dowithTaskStatus`) 추가
- 받은 잔소리 응답에 잔소리 받은 시각(`receivedAt`) 추가
- 컨트롤러 및 서비스 레이어 응답 타입 일치화

### QueryRepository 쿼리 개선

- `getFeedbacksBySenderId` 반환 타입을 `SentDowithTaskFeedbackQueryDto`로 분리
- `DowithTask` 조인 추가하여 task status 조회
- `fetchJoin` 제거 후 일반 `leftJoin`으로 변경
- `DowithTaskFeedbackQueryDto`에 `receivedAt` 필드 추가

### 기타

- Auth client(`AppleAuthClient`, `GoogleAuthClient`) `@Profile` 주석 포맷 수정

## 기타 전달 사항

- Swagger 변경사항은 컨트롤러 `@Operation` description 업데이트 포함.