### PR TITLE
[TAS-710] 잔소리 가능 두윗 조회 API totalCount 갯수 표시 수정

### DIFF
--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/task/dto/RetrieveFeedbackAvailableDowithTasksResult.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/task/dto/RetrieveFeedbackAvailableDowithTasksResult.java
@@ -7,12 +7,14 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
-public record RetrieveFeedbackAvailableDowithTasksResult(List<FeedbackAvailableDowithTaskDto> dowithTasks) {
+public record RetrieveFeedbackAvailableDowithTasksResult(
+        Long totalCount, List<FeedbackAvailableDowithTaskDto> dowithTasks) {
 
-    public static RetrieveFeedbackAvailableDowithTasksResult from(List<FeedbackAvailableDowithTasksQueryDto> dto) {
+    public static RetrieveFeedbackAvailableDowithTasksResult from(
+            Long totalCount, List<FeedbackAvailableDowithTasksQueryDto> dto) {
         List<FeedbackAvailableDowithTaskDto> dowithTasks =
                 dto.stream().map(FeedbackAvailableDowithTaskDto::from).toList();
-        return new RetrieveFeedbackAvailableDowithTasksResult(dowithTasks);
+        return new RetrieveFeedbackAvailableDowithTasksResult(totalCount, dowithTasks);
     }
 
     public record FeedbackAvailableDowithTaskDto(

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/task/service/RetrieveTaskService.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/task/service/RetrieveTaskService.java
@@ -11,7 +11,11 @@ import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.DowithTaskFeedback
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.SentFeedbacksQueryDto;
 import com.LetMeDoWith.LetMeDoWith.domain.task.repository.DowithTaskQueryRepository;
 import com.LetMeDoWith.LetMeDoWith.domain.task.repository.TodoTaskQueryRepository;
-import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.*;
+import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.DowithTaskDetailQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.DowithTaskQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.FeedbackAvailableDowithTasksQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.TodoTaskDetailQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.TodoTaskQueryDto;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.Year;
@@ -92,7 +96,7 @@ public class RetrieveTaskService {
                 dowithTaskQueryRepository.getFeedbackAvailableDowithTasks(pageable.getOffset(), pageable.getPageSize());
 
         if (feedbackAvailableDowithTasks.isEmpty()) {
-            return RetrieveFeedbackAvailableDowithTasksResult.from(feedbackAvailableDowithTasks);
+            return RetrieveFeedbackAvailableDowithTasksResult.from(0L, feedbackAvailableDowithTasks);
         }
 
         List<Long> taskIds = feedbackAvailableDowithTasks.stream()
@@ -117,6 +121,7 @@ public class RetrieveTaskService {
                 })
                 .toList();
 
-        return RetrieveFeedbackAvailableDowithTasksResult.from(tasks);
+        return RetrieveFeedbackAvailableDowithTasksResult.from(
+                dowithTaskQueryRepository.countFeedbackAvailableDowithTasks(), tasks);
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/task/repository/DowithTaskQueryRepository.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/task/repository/DowithTaskQueryRepository.java
@@ -25,6 +25,8 @@ public interface DowithTaskQueryRepository {
 
     List<FeedbackAvailableDowithTasksQueryDto> getFeedbackAvailableDowithTasks(Long offset, int size);
 
+    Long countFeedbackAvailableDowithTasks();
+
     List<FailedDowithTaskCountQueryDto> getFailedTaskCountsByMember(
             LocalDateTime aggregationStartDateTime, LocalDateTime aggregationEndDateTime);
 

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/task/query/DowithTaskQueryRespositoryImpl.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/task/query/DowithTaskQueryRespositoryImpl.java
@@ -6,9 +6,18 @@ import com.LetMeDoWith.LetMeDoWith.domain.member.model.QBadge;
 import com.LetMeDoWith.LetMeDoWith.domain.member.model.QMember;
 import com.LetMeDoWith.LetMeDoWith.domain.member.model.QMemberBadge;
 import com.LetMeDoWith.LetMeDoWith.domain.task.enums.DowithTaskStatus;
-import com.LetMeDoWith.LetMeDoWith.domain.task.model.*;
+import com.LetMeDoWith.LetMeDoWith.domain.task.model.QDowithTask;
+import com.LetMeDoWith.LetMeDoWith.domain.task.model.QDowithTaskLike;
+import com.LetMeDoWith.LetMeDoWith.domain.task.model.QDowithTaskRoutine;
+import com.LetMeDoWith.LetMeDoWith.domain.task.model.QDowithTaskSuccess;
+import com.LetMeDoWith.LetMeDoWith.domain.task.model.QTaskCategory;
 import com.LetMeDoWith.LetMeDoWith.domain.task.repository.DowithTaskQueryRepository;
-import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.*;
+import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.DowithTaskDetailQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.DowithTaskQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.FailedDowithTaskCountQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.FeedbackAvailableDowithTasksQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.MemberTaskSuccessStatsQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.repository.dto.SuccessDowithTaskQueryDto;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
@@ -21,7 +30,11 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -167,32 +180,6 @@ public class DowithTaskQueryRespositoryImpl implements DowithTaskQueryRepository
 
     @Override
     public List<FeedbackAvailableDowithTasksQueryDto> getFeedbackAvailableDowithTasks(Long offset, int size) {
-
-        LocalDateTime now = SystemTimeUtil.now();
-
-        LocalDate today = now.toLocalDate();
-        LocalTime nowTime = now.toLocalTime();
-
-        LocalDateTime startRangeDateTime = now.minusMinutes(59).minusSeconds(59);
-        LocalDate startRangeDate = startRangeDateTime.toLocalDate();
-        LocalTime startRangeTime = startRangeDateTime.toLocalTime();
-
-        BooleanBuilder condition = new BooleanBuilder();
-        condition.and(dowithTask.status.eq(DowithTaskStatus.WAIT));
-
-        if (today.equals(startRangeDate)) {
-            // Case 1: 범위 시작과 끝이 같은 날짜인 경우
-            condition.and(dowithTask
-                    .date
-                    .eq(today)
-                    .and(dowithTask.startTime.gt(startRangeTime))
-                    .and(dowithTask.startTime.loe(nowTime)));
-        } else {
-            // Case 2: 날짜가 걸쳐있는 경우 (자정 직후)
-            condition.and((dowithTask.date.eq(startRangeDate).and(dowithTask.startTime.gt(startRangeTime)))
-                    .or(dowithTask.date.eq(today).and(dowithTask.startTime.loe(nowTime))));
-        }
-
         return queryFactory
                 .select(Projections.constructor(
                         FeedbackAvailableDowithTasksQueryDto.class,
@@ -214,10 +201,19 @@ public class DowithTaskQueryRespositoryImpl implements DowithTaskQueryRepository
                 .on(memberBadge.memberId.eq(member.id).and(memberBadge.isMain.eq(Yn.TRUE)))
                 .leftJoin(badge)
                 .on(badge.id.eq(memberBadge.badge.id))
-                .where(condition)
+                .where(buildFeedbackAvailableCondition())
                 .offset(offset)
                 .limit(size)
                 .fetch();
+    }
+
+    @Override
+    public Long countFeedbackAvailableDowithTasks() {
+        return queryFactory
+                .select(dowithTask.count())
+                .from(dowithTask)
+                .where(buildFeedbackAvailableCondition())
+                .fetchOne();
     }
 
     @Override
@@ -279,5 +275,34 @@ public class DowithTaskQueryRespositoryImpl implements DowithTaskQueryRepository
                 .groupBy(dowithTask.memberId)
                 .having(registeredTaskCount.goe(5L))
                 .fetch();
+    }
+
+    private BooleanBuilder buildFeedbackAvailableCondition() {
+        LocalDateTime now = SystemTimeUtil.now();
+
+        LocalDate today = now.toLocalDate();
+        LocalTime nowTime = now.toLocalTime();
+
+        LocalDateTime startRangeDateTime = now.minusMinutes(59).minusSeconds(59);
+        LocalDate startRangeDate = startRangeDateTime.toLocalDate();
+        LocalTime startRangeTime = startRangeDateTime.toLocalTime();
+
+        BooleanBuilder condition = new BooleanBuilder();
+        condition.and(dowithTask.status.eq(DowithTaskStatus.WAIT));
+
+        if (today.equals(startRangeDate)) {
+            // Case 1: 범위 시작과 끝이 같은 날짜인 경우
+            condition.and(dowithTask
+                    .date
+                    .eq(today)
+                    .and(dowithTask.startTime.gt(startRangeTime))
+                    .and(dowithTask.startTime.loe(nowTime)));
+        } else {
+            // Case 2: 날짜가 걸쳐있는 경우 (자정 직후)
+            condition.and((dowithTask.date.eq(startRangeDate).and(dowithTask.startTime.gt(startRangeTime)))
+                    .or(dowithTask.date.eq(today).and(dowithTask.startTime.loe(nowTime))));
+        }
+
+        return condition;
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/task/controller/DowithTaskController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/task/controller/DowithTaskController.java
@@ -4,7 +4,12 @@ import com.LetMeDoWith.LetMeDoWith.application.task.dto.CancelLikeSuccessDowithT
 import com.LetMeDoWith.LetMeDoWith.application.task.dto.LikeSuccessDowithTaskResult;
 import com.LetMeDoWith.LetMeDoWith.application.task.dto.RetrieveDowithTaskResult;
 import com.LetMeDoWith.LetMeDoWith.application.task.dto.RetrieveFeedbackAvailableDowithTasksResult;
-import com.LetMeDoWith.LetMeDoWith.application.task.service.*;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.CreateDowithTaskService;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.DeleteDowithTaskService;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.RetrieveTaskService;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.SuccessDowithTaskService;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.TaskSummaryService;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.UpdateDowithTaskService;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponse;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponses;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiSuccessResponse;
@@ -14,7 +19,19 @@ import com.LetMeDoWith.LetMeDoWith.common.dto.ResponsePageDto;
 import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
 import com.LetMeDoWith.LetMeDoWith.common.util.AuthUtil;
 import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
-import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.*;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.CancelLikeDowithTaskResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.CreateDowithTaskReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.GenerateDowithTaskSuccessImageUploadPresignedUrlsReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.GenerateDowithTaskSuccessImageUploadPresignedUrlsResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.GetRemainedDowithTaskCountRes;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.LikeDowithTaskResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.RetrieveDowithTaskResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.RetrieveFeedbackAvailableDowithTasksResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.RetrieveSuccessDowithTasksRes;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.SuccessDowithTaskReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.UpdateDowithTaskReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.UpdateDowithTaskRoutineReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.UpdateDowithTaskWithRoutineReqDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -23,7 +40,14 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Dowith Task", description = "두윗모드 테스크")
 @RestController
@@ -40,9 +64,11 @@ public class DowithTaskController {
 
     @Operation(summary = "두윗모드 Task 조회")
     @ApiSuccessResponse(description = "두윗모드 Task 조회 성공")
-    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
+    @ApiErrorResponses({
+        @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
     @GetMapping("/{dowithTaskId}")
-    public ResponseEntity<ResponseDto<RetrieveDowithTaskResDto>> retrieveDowithTask(@PathVariable Long dowithTaskId) {
+    public ResponseEntity<ResponseDto<RetrieveDowithTaskResDto>> retrieveDowithTask(
+        @PathVariable Long dowithTaskId) {
         RetrieveDowithTaskResult result = this.retrieveTaskService.retrieveDowithTask(dowithTaskId);
         return ResponseUtil.createSuccessResponse(RetrieveDowithTaskResDto.from(result));
     }
@@ -50,26 +76,27 @@ public class DowithTaskController {
     @Operation(summary = "성공 Dowith Task 조회 (인증 사진 조회)")
     @GetMapping("/success")
     public ResponseEntity<ResponsePageDto<RetrieveSuccessDowithTasksRes>> retrieveSuccessDowithTasks(
-            @ParameterObject Pageable pageable) {
+        @ParameterObject Pageable pageable) {
         String requestMemberId = AuthUtil.getMemberId();
-        var result = this.successDowithTaskService.retrieveSuccessDowithTasks(requestMemberId, pageable);
+        var result = this.successDowithTaskService.retrieveSuccessDowithTasks(requestMemberId,
+            pageable);
         return ResponseUtil.createSuccessResponse(
-                RetrieveSuccessDowithTasksRes.from(result), pageable, result.totalCount());
+            RetrieveSuccessDowithTasksRes.from(result), pageable, result.totalCount());
     }
 
     @Operation(summary = "두윗모드 Task 생성", description = "두윗모드 테스크를 생성합니다.")
     @ApiSuccessResponse(description = "두윗모드 Task 생성 성공.")
-    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
+    @ApiErrorResponses({
+        @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
     @PostMapping("")
     public ResponseEntity<ResponseDto<Object>> createDowithTask(
-            @Valid @RequestBody CreateDowithTaskReqDto requestBody) {
-
-        String memberId = AuthUtil.getMemberId();
+        @Valid @RequestBody CreateDowithTaskReqDto requestBody) {
 
         if (requestBody.routineCondition() == null) {
             createDowithTaskService.createDowithTask(requestBody.toCreateDowithTaskCommand());
         } else {
-            createDowithTaskService.createDowithTaskWithRoutine(requestBody.toCreateDowithTaskWithRoutineCommand());
+            createDowithTaskService.createDowithTaskWithRoutine(
+                requestBody.toCreateDowithTaskWithRoutineCommand());
         }
 
         return ResponseUtil.createSuccessResponse();
@@ -79,9 +106,9 @@ public class DowithTaskController {
     @ApiSuccessResponse(description = "두윗모드 Task 수정 성공")
     @ApiErrorResponses({
         @ApiErrorResponse(
-                status = FailResponseStatus.INVALID_PARAM_ERROR,
-                description =
-                        "Request Body의 title이 공백이거나, 40자 초과인경우 / date, startTime이 null인 경우 / routine의 startDate가 date와 일치하지 않는 경우"),
+            status = FailResponseStatus.INVALID_PARAM_ERROR,
+            description =
+                "Request Body의 title이 공백이거나, 40자 초과인경우 / date, startTime이 null인 경우 / routine의 startDate가 date와 일치하지 않는 경우"),
         @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우"),
         //        @ApiErrorResponse(
         //                status = FailResponseStatus.DOWITH_TASK_CREATE_COUNT_EXCEED,
@@ -89,7 +116,7 @@ public class DowithTaskController {
     })
     @PutMapping("/{dowithTaskId}")
     public ResponseEntity<ResponseDto<Object>> updateDowithTask(
-            @PathVariable Long dowithTaskId, @RequestBody UpdateDowithTaskReqDto requestBody) {
+        @PathVariable Long dowithTaskId, @RequestBody UpdateDowithTaskReqDto requestBody) {
 
         updateDowithTaskService.updateDowithTask(requestBody.toCommand(dowithTaskId));
         return ResponseUtil.createSuccessResponse();
@@ -99,9 +126,9 @@ public class DowithTaskController {
     @ApiSuccessResponse(description = "두윗모드 Task 수정 성공")
     @ApiErrorResponses({
         @ApiErrorResponse(
-                status = FailResponseStatus.INVALID_PARAM_ERROR,
-                description =
-                        "Request Body의 title이 공백이거나, 40자 초과인경우 / date, startTime이 null인 경우 / routine의 startDate가 date와 일치하지 않는 경우"),
+            status = FailResponseStatus.INVALID_PARAM_ERROR,
+            description =
+                "Request Body의 title이 공백이거나, 40자 초과인경우 / date, startTime이 null인 경우 / routine의 startDate가 date와 일치하지 않는 경우"),
         @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우"),
         //        @ApiErrorResponse(
         //                status = FailResponseStatus.DOWITH_TASK_CREATE_COUNT_EXCEED,
@@ -109,7 +136,8 @@ public class DowithTaskController {
     })
     @PutMapping("/{dowithTaskId}/with-routine")
     public ResponseEntity<ResponseDto<Object>> updateDowithTaskWithRoutine(
-            @PathVariable Long dowithTaskId, @RequestBody UpdateDowithTaskWithRoutineReqDto requestBody) {
+        @PathVariable Long dowithTaskId,
+        @RequestBody UpdateDowithTaskWithRoutineReqDto requestBody) {
 
         updateDowithTaskService.updateDowithTaskWithRoutine(requestBody.toCommand(dowithTaskId));
         return ResponseUtil.createSuccessResponse();
@@ -119,14 +147,14 @@ public class DowithTaskController {
     @ApiSuccessResponse(description = "두윗모드 Task 루틴 수정 성공")
     @ApiErrorResponses({
         @ApiErrorResponse(
-                status = FailResponseStatus.INVALID_PARAM_ERROR,
-                description =
-                        "Request Body의 title이 공백이거나, 40자 초과인경우 / date, startTime이 null인 경우 / routine의 startDate가 date와 일치하지 않는 경우"),
+            status = FailResponseStatus.INVALID_PARAM_ERROR,
+            description =
+                "Request Body의 title이 공백이거나, 40자 초과인경우 / date, startTime이 null인 경우 / routine의 startDate가 date와 일치하지 않는 경우"),
         @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")
     })
     @PutMapping("/{dowithTaskId}/routine")
     public ResponseEntity<ResponseDto<Object>> updateDowithTaskRoutine(
-            @PathVariable Long dowithTaskId, @RequestBody UpdateDowithTaskRoutineReqDto requestBody) {
+        @PathVariable Long dowithTaskId, @RequestBody UpdateDowithTaskRoutineReqDto requestBody) {
 
         updateDowithTaskService.updateRoutine(requestBody.toCommand(dowithTaskId));
 
@@ -135,7 +163,8 @@ public class DowithTaskController {
 
     @Operation(summary = "두윗모드 Task 삭제", description = "두윗모드 Task를 삭제합니다.")
     @ApiSuccessResponse(description = "두윗모드 Task 삭제 성공")
-    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
+    @ApiErrorResponses({
+        @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
     @DeleteMapping("/{dowithTaskId}")
     public ResponseEntity deleteDowithTask(@PathVariable Long dowithTaskId) {
 
@@ -146,9 +175,11 @@ public class DowithTaskController {
 
     @Operation(summary = "두윗모드 Task(Routine 포함) 삭제", description = "두윗모드 Task(Routine 포함)를 삭제합니다.")
     @ApiSuccessResponse(description = "두윗모드 Task(Routine 포함) 삭제 성공")
-    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
+    @ApiErrorResponses({
+        @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
     @DeleteMapping("/{dowithTaskId}/with-routine")
-    public ResponseEntity<ResponseDto<Object>> deleteDowithTaskWithRoutine(@PathVariable Long dowithTaskId) {
+    public ResponseEntity<ResponseDto<Object>> deleteDowithTaskWithRoutine(
+        @PathVariable Long dowithTaskId) {
 
         deleteDowithTaskService.deleteWithRoutines(AuthUtil.getMemberId(), dowithTaskId);
 
@@ -157,82 +188,93 @@ public class DowithTaskController {
 
     @Operation(summary = "두윗모드 Task 인증 이미지 upload presigned url 발급")
     @ApiSuccessResponse(
-            description =
-                    "요청 시의 imageFileNames 수 만큼 presigned url이 발급됩니다. method를 참고하여 presigned url 하나당 이미지 하나를 http request 하여 업로드합니다.")
-    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
+        description =
+            "요청 시의 imageFileNames 수 만큼 presigned url이 발급됩니다. method를 참고하여 presigned url 하나당 이미지 하나를 http request 하여 업로드합니다.")
+    @ApiErrorResponses({
+        @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
     @PostMapping("/{dowithTaskId}/success/image/upload-presigned-url")
     public ResponseEntity<ResponseDto<GenerateDowithTaskSuccessImageUploadPresignedUrlsResDto>>
-            generateDowithTaskSuccessImageUploadPresignedUrls(
-                    @PathVariable Long dowithTaskId,
-                    @RequestBody GenerateDowithTaskSuccessImageUploadPresignedUrlsReqDto requestBody) {
+    generateDowithTaskSuccessImageUploadPresignedUrls(
+        @PathVariable Long dowithTaskId,
+        @RequestBody GenerateDowithTaskSuccessImageUploadPresignedUrlsReqDto requestBody) {
 
         String memberId = AuthUtil.getMemberId();
 
         GenerateUploadPresignedUrlsResult result =
-                successDowithTaskService.generateDowithTaskSuccessImageUploadPresignedUrls(
-                        memberId, dowithTaskId, requestBody.imageFileNames());
+            successDowithTaskService.generateDowithTaskSuccessImageUploadPresignedUrls(
+                memberId, dowithTaskId, requestBody.imageFileNames());
 
-        return ResponseUtil.createSuccessResponse(new GenerateDowithTaskSuccessImageUploadPresignedUrlsResDto(
+        return ResponseUtil.createSuccessResponse(
+            new GenerateDowithTaskSuccessImageUploadPresignedUrlsResDto(
                 result.publicImageUrls(), result.presignedUrls(), result.method()));
     }
 
     @Operation(summary = "두윗모드 Task 인증", description = "Presigned url을 통해서 업로드한 파일의 public url을 body에 담아 요청합니다.")
     @ApiSuccessResponse(description = "두윗모드 Task 인증 성공")
-    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
+    @ApiErrorResponses({
+        @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
     @PostMapping("/{dowithTaskId}/success")
     public ResponseEntity<ResponseDto<Object>> successDowithTask(
-            @PathVariable Long dowithTaskId, @RequestBody SuccessDowithTaskReqDto requestBody) {
+        @PathVariable Long dowithTaskId, @RequestBody SuccessDowithTaskReqDto requestBody) {
 
         String memberId = AuthUtil.getMemberId();
 
-        successDowithTaskService.successDowithTask(memberId, dowithTaskId, requestBody.publicImageUrls());
+        successDowithTaskService.successDowithTask(memberId, dowithTaskId,
+            requestBody.publicImageUrls());
 
         return ResponseUtil.createSuccessResponse();
     }
 
     @Operation(summary = "두윗모드 Task 좋아요", description = "두윗모드 Task에 좋아요를 합니다.")
     @ApiSuccessResponse(description = "두윗모드 Task 좋아요")
-    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
+    @ApiErrorResponses({
+        @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
     @PostMapping("/{dowithTaskId}/like")
-    public ResponseEntity<ResponseDto<LikeDowithTaskResDto>> likeDowithTask(@PathVariable Long dowithTaskId) {
+    public ResponseEntity<ResponseDto<LikeDowithTaskResDto>> likeDowithTask(
+        @PathVariable Long dowithTaskId) {
         String memberId = AuthUtil.getMemberId();
-        LikeSuccessDowithTaskResult result = successDowithTaskService.likeSuccessDowithTask(memberId, dowithTaskId);
+        LikeSuccessDowithTaskResult result = successDowithTaskService.likeSuccessDowithTask(
+            memberId, dowithTaskId);
         return ResponseUtil.createSuccessResponse(
-                new LikeDowithTaskResDto(result.isAlreadyLiked(), result.likeCount()));
+            new LikeDowithTaskResDto(result.isAlreadyLiked(), result.likeCount()));
     }
 
     @Operation(summary = "두윗모드 Task 좋아요 취소", description = "두윗모드 Task에 좋아요를 취소합니다.")
     @ApiSuccessResponse(description = "두윗모드 Task 좋아요 취소")
-    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
+    @ApiErrorResponses({
+        @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
     @DeleteMapping("/{dowithTaskId}/like")
     public ResponseEntity<ResponseDto<CancelLikeDowithTaskResDto>> cancelLikeDowithTask(
-            @PathVariable Long dowithTaskId) {
+        @PathVariable Long dowithTaskId) {
         String memberId = AuthUtil.getMemberId();
         CancelLikeSuccessDowithTaskResult result =
-                successDowithTaskService.cancelLikeSuccessDowithTask(memberId, dowithTaskId);
+            successDowithTaskService.cancelLikeSuccessDowithTask(memberId, dowithTaskId);
         return ResponseUtil.createSuccessResponse(
-                new CancelLikeDowithTaskResDto(result.isAlreadyCanceled(), result.likeCount()));
+            new CancelLikeDowithTaskResDto(result.isAlreadyCanceled(), result.likeCount()));
     }
 
     @Operation(summary = "두윗모드 Task 잔여 개수 조회", description = "두윗모드 Task의 잔여 개수를 조회합니다.")
     @ApiSuccessResponse(description = "두윗모드 Task 잔여 개수 조회 성공")
-    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
+    @ApiErrorResponses({
+        @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우")})
     @GetMapping("/remained")
     public ResponseEntity<ResponseDto<GetRemainedDowithTaskCountRes>> getRemainedDowithTaskCount() {
-        int remainedDowithTaskCount = taskSummaryService.getRemainedDowithTaskCount(AuthUtil.getMemberId());
-        return ResponseUtil.createSuccessResponse(new GetRemainedDowithTaskCountRes(remainedDowithTaskCount));
+        int remainedDowithTaskCount = taskSummaryService.getRemainedDowithTaskCount(
+            AuthUtil.getMemberId());
+        return ResponseUtil.createSuccessResponse(
+            new GetRemainedDowithTaskCountRes(remainedDowithTaskCount));
     }
 
     @Operation(summary = "잔소리 가능한 두윗 태스크 목록 조회")
     @ApiSuccessResponse(description = "잔소리 가능한 두윗 태스크 목록 조회 성공")
     @GetMapping("/feedback-available")
     public ResponseEntity<ResponsePageDto<RetrieveFeedbackAvailableDowithTasksResDto>>
-            retrieveFeedbackAvailableDowithTasks(@PageableDefault(size = 20) Pageable pageable) {
+    retrieveFeedbackAvailableDowithTasks(@PageableDefault(size = 20) Pageable pageable) {
 
         RetrieveFeedbackAvailableDowithTasksResult result =
-                retrieveTaskService.retrieveFeedbackAvailableDowithTasks(pageable);
+            retrieveTaskService.retrieveFeedbackAvailableDowithTasks(pageable);
 
         return ResponseUtil.createSuccessResponse(
-                RetrieveFeedbackAvailableDowithTasksResDto.from(result), pageable, -1L);
+            RetrieveFeedbackAvailableDowithTasksResDto.from(result), pageable, result.totalCount());
     }
 }

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/task/RetrieveFeedbackAvailableDowithTasksIntegrationTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/task/RetrieveFeedbackAvailableDowithTasksIntegrationTest.java
@@ -144,8 +144,8 @@ public class RetrieveFeedbackAvailableDowithTasksIntegrationTest extends Abstrac
         ResponsePageDto<RetrieveFeedbackAvailableDowithTasksResDto> pageResponse = requestFeedbackAvailablePage(0, 20);
         RetrieveFeedbackAvailableDowithTasksResDto response = pageResponse.data();
 
-        assertThat(pageResponse.totalCount()).isEqualTo(-1L);
-        assertThat(pageResponse.totalPage()).isEqualTo(0);
+        assertThat(pageResponse.totalCount()).isEqualTo(3L);
+        assertThat(pageResponse.totalPage()).isEqualTo(1);
 
         List<RetrieveFeedbackAvailableDowithTaskResDto> tasks = response.dowithTasks();
         List<Long> ids = tasks.stream()
@@ -183,8 +183,8 @@ public class RetrieveFeedbackAvailableDowithTasksIntegrationTest extends Abstrac
         ResponsePageDto<RetrieveFeedbackAvailableDowithTasksResDto> pageResponse = requestFeedbackAvailablePage(0, 20);
         RetrieveFeedbackAvailableDowithTasksResDto response = pageResponse.data();
 
-        assertThat(pageResponse.totalCount()).isEqualTo(-1L);
-        assertThat(pageResponse.totalPage()).isEqualTo(0);
+        assertThat(pageResponse.totalCount()).isEqualTo(2L);
+        assertThat(pageResponse.totalPage()).isEqualTo(1);
 
         List<Long> ids = response.dowithTasks().stream()
                 .map(RetrieveFeedbackAvailableDowithTaskResDto::id)
@@ -208,7 +208,7 @@ public class RetrieveFeedbackAvailableDowithTasksIntegrationTest extends Abstrac
         ResponsePageDto<RetrieveFeedbackAvailableDowithTasksResDto> pageResponse = requestFeedbackAvailablePage(0, 20);
         RetrieveFeedbackAvailableDowithTasksResDto response = pageResponse.data();
 
-        assertThat(pageResponse.totalCount()).isEqualTo(-1L);
+        assertThat(pageResponse.totalCount()).isEqualTo(0L);
         assertThat(pageResponse.totalPage()).isEqualTo(0);
         assertThat(response.dowithTasks()).isEmpty();
     }
@@ -221,10 +221,10 @@ public class RetrieveFeedbackAvailableDowithTasksIntegrationTest extends Abstrac
         ResponsePageDto<RetrieveFeedbackAvailableDowithTasksResDto> page0 = requestFeedbackAvailablePage(0, 2);
         ResponsePageDto<RetrieveFeedbackAvailableDowithTasksResDto> page1 = requestFeedbackAvailablePage(1, 2);
 
-        assertThat(page0.totalCount()).isEqualTo(-1L);
-        assertThat(page1.totalCount()).isEqualTo(-1L);
-        assertThat(page0.totalPage()).isEqualTo(0);
-        assertThat(page1.totalPage()).isEqualTo(0);
+        assertThat(page0.totalCount()).isEqualTo(3L);
+        assertThat(page1.totalCount()).isEqualTo(3L);
+        assertThat(page0.totalPage()).isEqualTo(2);
+        assertThat(page1.totalPage()).isEqualTo(2);
 
         assertThat(page0.data().dowithTasks()).hasSize(2);
         assertThat(page1.data().dowithTasks()).hasSize(1);


### PR DESCRIPTION
## PR 체크리스트

Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [x] 모든 Test 코드를 실행하여 PASS했나요?
- [x] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

PR의 타입을 체크해주세요

- [x] 버그 픽스 - 이슈 링크 : https://www.notion.so/API-API-totalCount-1-34ddf3a3e43f80ed9fe4c3d48fdafc74?v=72865a96132e456c873537e8de4c3757&source=copy_link
- [ ] 신규 기능 개발
- [ ] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [ ] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타

## 백로그 및 이슈 링크

- 링크 : https://www.notion.so/API-API-totalCount-1-34ddf3a3e43f80ed9fe4c3d48fdafc74?v=72865a96132e456c873537e8de4c3757&source=copy_link

## 변경된 사항

### 잔소리 가능 두윗 조회 API `totalCount` 갯수 표시 수정

- 기존 `-1`로 하드코딩 되어있던 값을 제대로 계산하도록 수정함


## 기타 전달 사항

-
- 
