### PR TITLE
[TAS-701] 마이두윗 정보 조회 API

### DIFF
--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/member/dto/RetrieveMyDowithResult.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/member/dto/RetrieveMyDowithResult.java
@@ -1,0 +1,16 @@
+package com.LetMeDoWith.LetMeDoWith.application.member.dto;
+
+import com.LetMeDoWith.LetMeDoWith.domain.member.repository.dto.MemberDowithQueryDto;
+
+public record RetrieveMyDowithResult(
+        String memberId, String nickname, String selfDescription, String profileImageUrl, Long successDowithCount) {
+
+    public static RetrieveMyDowithResult from(MemberDowithQueryDto queryDto) {
+        return new RetrieveMyDowithResult(
+                queryDto.memberId(),
+                queryDto.nickname(),
+                queryDto.selfDescription(),
+                queryDto.profileImageUrl(),
+                queryDto.successDowithCount());
+    }
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/member/service/MemberService.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.LetMeDoWith.LetMeDoWith.application.member.service;
 
 import com.LetMeDoWith.LetMeDoWith.application.member.dto.CreateSignupCompletedMemberCommand;
 import com.LetMeDoWith.LetMeDoWith.application.member.dto.MemberPersonalInfoVO;
+import com.LetMeDoWith.LetMeDoWith.application.member.dto.RetrieveMyDowithResult;
 import com.LetMeDoWith.LetMeDoWith.common.dto.GenerateUploadPresignedUrlsResult;
 import com.LetMeDoWith.LetMeDoWith.common.enums.common.FileNamespace;
 import com.LetMeDoWith.LetMeDoWith.common.enums.member.MemberStatus;
@@ -12,6 +13,7 @@ import com.LetMeDoWith.LetMeDoWith.common.util.AuthUtil;
 import com.LetMeDoWith.LetMeDoWith.domain.auth.enums.SocialProvider;
 import com.LetMeDoWith.LetMeDoWith.domain.member.model.Member;
 import com.LetMeDoWith.LetMeDoWith.domain.member.model.MemberAlarmSetting;
+import com.LetMeDoWith.LetMeDoWith.domain.member.repository.MemberQueryRepository;
 import com.LetMeDoWith.LetMeDoWith.domain.member.repository.MemberRepository;
 import com.LetMeDoWith.LetMeDoWith.domain.member.repository.MemberSettingRepository;
 import java.util.Optional;
@@ -27,6 +29,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberSettingRepository memberSettingRepository;
+    private final MemberQueryRepository memberQueryRepository;
     private final PresignedUrlService presignedUrlService;
 
     /**
@@ -147,8 +150,8 @@ public class MemberService {
     /**
      * 회원의 프로필 정보를 업데이트합니다.
      *
-     * @param memberId 업데이트 대상 회원 id
-     * @param nickname 변경할 닉네임
+     * @param memberId        업데이트 대상 회원 id
+     * @param nickname        변경할 닉네임
      * @param selfDescription 변경할 자기소개
      * @param profileImageUrl 변경할 프로필 이미지 URL
      */
@@ -168,7 +171,7 @@ public class MemberService {
      *
      * <p>실제 업로드 권한 확인은 NORMAL 회원 여부만 검증하고, key 생성 및 URL 발급은 공통 서비스에 위임합니다.
      *
-     * @param memberId 프로필 이미지를 업로드하려는 회원 id
+     * @param memberId      프로필 이미지를 업로드하려는 회원 id
      * @param imageFileName 업로드할 프로필 이미지 파일명
      * @return 프로필 이미지 업로드용 presigned URL 결과
      */
@@ -180,5 +183,18 @@ public class MemberService {
 
         return presignedUrlService.generateUploadPresignedUrls(
                 FileNamespace.MEMBER_PROFILE, java.util.List.of(imageFileName));
+    }
+
+    /**
+     * 회원의 마이두윗 정보를 조회합니다.
+     *
+     * @param memberId 마이두윗을 조회하려는 회원 id
+     * @return 마이두윗 정보
+     */
+    public RetrieveMyDowithResult retrieveMyDowithInfo(String memberId) {
+        return memberQueryRepository
+                .getMyDowithInfo(memberId)
+                .map(RetrieveMyDowithResult::from)
+                .orElseThrow(() -> new RestApiException(FailResponseStatus.MEMBER_NOT_EXIST));
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/member/repository/MemberQueryRepository.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/member/repository/MemberQueryRepository.java
@@ -1,0 +1,9 @@
+package com.LetMeDoWith.LetMeDoWith.domain.member.repository;
+
+import com.LetMeDoWith.LetMeDoWith.domain.member.repository.dto.MemberDowithQueryDto;
+import java.util.Optional;
+
+public interface MemberQueryRepository {
+
+    Optional<MemberDowithQueryDto> getMyDowithInfo(String memberId);
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/member/repository/dto/MemberDowithQueryDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/member/repository/dto/MemberDowithQueryDto.java
@@ -1,0 +1,4 @@
+package com.LetMeDoWith.LetMeDoWith.domain.member.repository.dto;
+
+public record MemberDowithQueryDto(
+        String memberId, String nickname, String selfDescription, String profileImageUrl, Long successDowithCount) {}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/member/query/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/member/query/MemberQueryRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.LetMeDoWith.LetMeDoWith.domain.member.repository.dto.MemberDowithQuer
 import com.LetMeDoWith.LetMeDoWith.domain.task.enums.DowithTaskStatus;
 import com.LetMeDoWith.LetMeDoWith.domain.task.model.QDowithTask;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -30,12 +31,14 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
                         qMember.nickname,
                         qMember.selfDescription,
                         qMember.profileImageUrl,
-                        qDowithTask.id.count()))
+                        JPAExpressions.select(qDowithTask.id.count())
+                                .from(qDowithTask)
+                                .where(qDowithTask
+                                        .memberId
+                                        .eq(qMember.id)
+                                        .and(qDowithTask.status.eq(DowithTaskStatus.SUCCESS)))))
                 .from(qMember)
-                .leftJoin(qDowithTask)
-                .on(qDowithTask.memberId.eq(qMember.id).and(qDowithTask.status.eq(DowithTaskStatus.SUCCESS)))
                 .where(qMember.id.eq(memberId).and(qMember.status.eq(MemberStatus.NORMAL)))
-                .groupBy(qMember.id)
                 .fetchOne();
 
         return Optional.ofNullable(result);

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/member/query/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/member/query/MemberQueryRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.LetMeDoWith.LetMeDoWith.infrastructure.member.query;
+
+import com.LetMeDoWith.LetMeDoWith.common.enums.member.MemberStatus;
+import com.LetMeDoWith.LetMeDoWith.domain.member.model.QMember;
+import com.LetMeDoWith.LetMeDoWith.domain.member.repository.MemberQueryRepository;
+import com.LetMeDoWith.LetMeDoWith.domain.member.repository.dto.MemberDowithQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.task.enums.DowithTaskStatus;
+import com.LetMeDoWith.LetMeDoWith.domain.task.model.QDowithTask;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryRepositoryImpl implements MemberQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QMember qMember = QMember.member;
+    private final QDowithTask qDowithTask = QDowithTask.dowithTask;
+
+    @Override
+    public Optional<MemberDowithQueryDto> getMyDowithInfo(String memberId) {
+        MemberDowithQueryDto result = queryFactory
+                .select(Projections.constructor(
+                        MemberDowithQueryDto.class,
+                        qMember.id,
+                        qMember.nickname,
+                        qMember.selfDescription,
+                        qMember.profileImageUrl,
+                        qDowithTask.id.count()))
+                .from(qMember)
+                .leftJoin(qDowithTask)
+                .on(qDowithTask.memberId.eq(qMember.id).and(qDowithTask.status.eq(DowithTaskStatus.SUCCESS)))
+                .where(qMember.id.eq(memberId).and(qMember.status.eq(MemberStatus.NORMAL)))
+                .groupBy(qMember.id)
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/controller/MemberController.java
@@ -19,6 +19,7 @@ import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.CreateTokenResDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.CheckNicknameReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.GenerateMemberProfileImageUploadPresignedUrlReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.GenerateMemberProfileImageUploadPresignedUrlResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.RetrieveMyDowithResDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.SignupCompleteReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.UpdateMemberInfoReqDto;
 import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.UpdateMemberTermAgreeReqDto;
@@ -27,7 +28,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -171,5 +174,24 @@ public class MemberController {
 
         return ResponseUtil.createSuccessResponse(new GenerateMemberProfileImageUploadPresignedUrlResDto(
                 result.publicImageUrls().get(0), result.presignedUrls().get(0), result.method()));
+    }
+
+    @Operation(summary = "내 마이두윗 정보 조회", description = "내 기본 정보와 전체 기간 성공한 두윗 갯수를 조회합니다.")
+    @ApiSuccessResponse(description = "내 마이두윗 정보 조회 성공")
+    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.MEMBER_NOT_EXIST)})
+    @GetMapping("/me/my-dowith")
+    public ResponseEntity<ResponseDto<RetrieveMyDowithResDto>> retrieveMyDowithInfo() {
+        String memberId = AuthUtil.getMemberId();
+        return ResponseUtil.createSuccessResponse(
+                RetrieveMyDowithResDto.from(memberService.retrieveMyDowithInfo(memberId)));
+    }
+
+    @Operation(summary = "특정 멤버의 마이두윗 정보 조회", description = "특정 멤버의 기본 정보와 전체 기간 성공한 두윗 갯수를 조회합니다.")
+    @ApiSuccessResponse(description = "마이두윗 정보 조회 성공")
+    @ApiErrorResponses({@ApiErrorResponse(status = FailResponseStatus.MEMBER_NOT_EXIST)})
+    @GetMapping("/{memberId}/my-dowith")
+    public ResponseEntity<ResponseDto<RetrieveMyDowithResDto>> retrieveMemberDowithInfo(@PathVariable String memberId) {
+        return ResponseUtil.createSuccessResponse(
+                RetrieveMyDowithResDto.from(memberService.retrieveMyDowithInfo(memberId)));
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/RetrieveMyDowithResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/RetrieveMyDowithResDto.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record RetrieveMyDowithResDto(
         @Schema(description = "회원 ID") String memberId,
         @Schema(description = "닉네임") String nickname,
-        @Schema(description = "상태 메세지") String description,
+        @Schema(description = "상태 메세지") String selfDescription,
         @Schema(description = "프로필 이미지 URL") String profileImageUrl,
         @Schema(description = "전체 기간 성공한 두윗 갯수") Long successDowithCount) {
 

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/RetrieveMyDowithResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/member/dto/RetrieveMyDowithResDto.java
@@ -1,0 +1,22 @@
+package com.LetMeDoWith.LetMeDoWith.presentation.member.dto;
+
+import com.LetMeDoWith.LetMeDoWith.application.member.dto.RetrieveMyDowithResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "마이두윗 정보 조회 응답")
+public record RetrieveMyDowithResDto(
+        @Schema(description = "회원 ID") String memberId,
+        @Schema(description = "닉네임") String nickname,
+        @Schema(description = "상태 메세지") String description,
+        @Schema(description = "프로필 이미지 URL") String profileImageUrl,
+        @Schema(description = "전체 기간 성공한 두윗 갯수") Long successDowithCount) {
+
+    public static RetrieveMyDowithResDto from(RetrieveMyDowithResult result) {
+        return new RetrieveMyDowithResDto(
+                result.memberId(),
+                result.nickname(),
+                result.selfDescription(),
+                result.profileImageUrl(),
+                result.successDowithCount());
+    }
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/task/controller/DowithTaskController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/task/controller/DowithTaskController.java
@@ -4,7 +4,12 @@ import com.LetMeDoWith.LetMeDoWith.application.task.dto.CancelLikeSuccessDowithT
 import com.LetMeDoWith.LetMeDoWith.application.task.dto.LikeSuccessDowithTaskResult;
 import com.LetMeDoWith.LetMeDoWith.application.task.dto.RetrieveDowithTaskResult;
 import com.LetMeDoWith.LetMeDoWith.application.task.dto.RetrieveFeedbackAvailableDowithTasksResult;
-import com.LetMeDoWith.LetMeDoWith.application.task.service.*;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.CreateDowithTaskService;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.DeleteDowithTaskService;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.RetrieveTaskService;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.SuccessDowithTaskService;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.TaskSummaryService;
+import com.LetMeDoWith.LetMeDoWith.application.task.service.UpdateDowithTaskService;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponse;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponses;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiSuccessResponse;
@@ -14,7 +19,19 @@ import com.LetMeDoWith.LetMeDoWith.common.dto.ResponsePageDto;
 import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
 import com.LetMeDoWith.LetMeDoWith.common.util.AuthUtil;
 import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
-import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.*;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.CancelLikeDowithTaskResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.CreateDowithTaskReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.GenerateDowithTaskSuccessImageUploadPresignedUrlsReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.GenerateDowithTaskSuccessImageUploadPresignedUrlsResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.GetRemainedDowithTaskCountRes;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.LikeDowithTaskResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.RetrieveDowithTaskResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.RetrieveFeedbackAvailableDowithTasksResDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.RetrieveSuccessDowithTasksRes;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.SuccessDowithTaskReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.UpdateDowithTaskReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.UpdateDowithTaskRoutineReqDto;
+import com.LetMeDoWith.LetMeDoWith.presentation.task.dto.UpdateDowithTaskWithRoutineReqDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -23,7 +40,14 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Dowith Task", description = "두윗모드 테스크")
 @RestController
@@ -85,7 +109,7 @@ public class DowithTaskController {
         @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우"),
         //        @ApiErrorResponse(
         //                status = FailResponseStatus.DOWITH_TASK_CREATE_COUNT_EXCEED,
-        //                description = "일일 두윗모드 Task 등록 가능 개수를 초과한 경우")
+        //                selfDescription = "일일 두윗모드 Task 등록 가능 개수를 초과한 경우")
     })
     @PutMapping("/{dowithTaskId}")
     public ResponseEntity<ResponseDto<Object>> updateDowithTask(
@@ -105,7 +129,7 @@ public class DowithTaskController {
         @ApiErrorResponse(status = FailResponseStatus.INVALID_REQUEST, description = "잘못된 요청인 경우"),
         //        @ApiErrorResponse(
         //                status = FailResponseStatus.DOWITH_TASK_CREATE_COUNT_EXCEED,
-        //                description = "일일 두윗모드 Task 등록 가능 개수를 초과한 경우")
+        //                selfDescription = "일일 두윗모드 Task 등록 가능 개수를 초과한 경우")
     })
     @PutMapping("/{dowithTaskId}/with-routine")
     public ResponseEntity<ResponseDto<Object>> updateDowithTaskWithRoutine(

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/member/MyDowithIntegrationTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/member/MyDowithIntegrationTest.java
@@ -1,0 +1,121 @@
+package com.LetMeDoWith.LetMeDoWith.integration.member;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.LetMeDoWith.LetMeDoWith.common.util.SystemTimeUtil;
+import com.LetMeDoWith.LetMeDoWith.domain.task.model.DowithTask;
+import com.LetMeDoWith.LetMeDoWith.infrastructure.task.persistence.jpaRepository.DowithTaskJpaRepository;
+import com.LetMeDoWith.LetMeDoWith.integration.AbstractIntegrationTest;
+import com.LetMeDoWith.LetMeDoWith.presentation.member.dto.RetrieveMyDowithResDto;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class MyDowithIntegrationTest extends AbstractIntegrationTest {
+
+    static final String MY_DOWITH_URL = "/api/v1/members/me/my-dowith";
+    static final String MEMBER_DOWITH_URL = "/api/v1/members/%s/my-dowith";
+
+    @Autowired
+    DowithTaskJpaRepository dowithTaskJpaRepository;
+
+    @Override
+    protected void deleteTestData() {
+        dowithTaskJpaRepository.deleteAll();
+    }
+
+    @Override
+    protected void createTestData() {
+        SystemTimeUtil.setClock(
+                Clock.fixed(LocalDateTime.of(2024, 3, 1, 0, 0).toInstant(ZoneOffset.UTC), ZoneOffset.UTC));
+
+        DowithTask successTask1 =
+                DowithTask.of(requestMember.getId(), null, "성공 두윗 1", LocalDate.of(2024, 3, 10), LocalTime.of(10, 0));
+        successTask1.success(List.of("https://example.com/image1.jpg"));
+
+        DowithTask successTask2 =
+                DowithTask.of(requestMember.getId(), null, "성공 두윗 2", LocalDate.of(2024, 3, 11), LocalTime.of(11, 0));
+        successTask2.success(List.of("https://example.com/image2.jpg"));
+
+        DowithTask waitTask =
+                DowithTask.of(requestMember.getId(), null, "대기 두윗", LocalDate.of(2024, 3, 12), LocalTime.of(12, 0));
+
+        dowithTaskJpaRepository.saveAll(List.of(successTask1, successTask2, waitTask));
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 내 마이두윗 정보 조회 - 기본 정보와 성공한 두윗 갯수를 반환한다.")
+    void retrieveMyDowithInfo() throws Exception {
+        // when
+        MvcResult result = this.request(MockMvcRequestBuilders.get(MY_DOWITH_URL))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        RetrieveMyDowithResDto resDto =
+                this.readResponse(result.getResponse().getContentAsString(), RetrieveMyDowithResDto.class);
+
+        // then
+        assertEquals(requestMember.getId(), resDto.memberId());
+        assertEquals(requestMember.getNickname(), resDto.nickname());
+        assertEquals(requestMember.getSelfDescription(), resDto.selfDescription());
+        assertEquals(2L, resDto.successDowithCount());
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 특정 멤버의 마이두윗 정보 조회 - 기본 정보와 성공한 두윗 갯수를 반환한다.")
+    void retrieveMemberDowithInfo() throws Exception {
+        // when
+        MvcResult result = this.request(MockMvcRequestBuilders.get(MEMBER_DOWITH_URL.formatted(requestMember.getId())))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        RetrieveMyDowithResDto resDto =
+                this.readResponse(result.getResponse().getContentAsString(), RetrieveMyDowithResDto.class);
+
+        // then
+        assertEquals(requestMember.getId(), resDto.memberId());
+        assertEquals(requestMember.getNickname(), resDto.nickname());
+        assertEquals(requestMember.getSelfDescription(), resDto.selfDescription());
+        assertEquals(2L, resDto.successDowithCount());
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 성공한 두윗이 없는 경우 - successDowithCount 0을 반환한다.")
+    void retrieveMyDowithInfoWithNoSuccessTasks() throws Exception {
+        // given
+        dowithTaskJpaRepository.deleteAll();
+
+        // when
+        MvcResult result = this.request(MockMvcRequestBuilders.get(MY_DOWITH_URL))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        RetrieveMyDowithResDto resDto =
+                this.readResponse(result.getResponse().getContentAsString(), RetrieveMyDowithResDto.class);
+
+        // then
+        assertEquals(requestMember.getId(), resDto.memberId());
+        assertEquals(0L, resDto.successDowithCount());
+    }
+
+    @Test
+    @DisplayName("[FAIL] 특정 멤버의 마이두윗 정보 조회 - 존재하지 않는 memberId로 요청 시 실패한다.")
+    void retrieveMemberDowithInfo_notFound() throws Exception {
+        // given
+        String nonExistentMemberId = "NON_EXISTENT_MEMBER_ID";
+
+        // when
+        this.request(MockMvcRequestBuilders.get(MEMBER_DOWITH_URL.formatted(nonExistentMemberId)))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+    }
+}


### PR DESCRIPTION
## PR 체크리스트

Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [x] 모든 Test 코드를 실행하여 PASS했나요?
- [x] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

- [x] 신규 기능 개발
- [x] 테스트 코드 추가

## 백로그 및 이슈 링크

- 링크 : TAS-701

## 변경된 사항

### MemberQueryRepository 추가 (domain/infrastructure)

- `MemberQueryRepository` 인터페이스 추가 (domain 레이어, RankingQueryRepository 패턴과 동일)
- `MemberDowithQueryDto` 추가 — member + 성공 두윗 갯수를 단일 쿼리로 조회하는 결과 DTO
- `MemberQueryRepositoryImpl` 추가 — QueryDSL로 `member LEFT JOIN dowith_task WHERE status=SUCCESS GROUP BY member.id`

### 마이두윗 정보 조회 API 추가 (application/presentation)

- `MemberService.retrieveMyDowithInfo(memberId)` 추가
- `GET /api/v1/members/me/my-dowith` — 내 마이두윗 정보 조회
- `GET /api/v1/members/{memberId}/my-dowith` — 특정 멤버 마이두윗 정보 조회
- 응답: memberId, nickname, selfDescription, profileImageUrl, successDowithCount

### 통합 테스트 추가

- 내 마이두윗 정보 조회 성공
- 특정 멤버 마이두윗 정보 조회 성공
- 성공한 두윗 없는 경우 (successDowithCount = 0)
- 존재하지 않는 memberId 요청 실패 (MEMBER_NOT_EXIST)

## 기타 전달 사항

- 뱃지 정보는 Out of Scope — 추후 v2에서 확장 예정