### PR TITLE
hotfix: 잔소리 조회 3개 API 템플릿 응답에서 message 대신 name 반환

### DIFF
--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveDowithTaskFeedbacksResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveDowithTaskFeedbacksResDto.java
@@ -44,12 +44,12 @@ public record RetrieveDowithTaskFeedbacksResDto(
     public record RetrieveTaskFeedbackTemplateDto(
             @Schema(description = "잔소리 템플릿 ID", example = "1") Long id,
             @Schema(description = "잔소리 템플릿 언어", example = "ko") CountryCode language,
-            @Schema(description = "잔소리 템플릿 메시지", example = "잔소리 템플릿 메시지") String message,
+            @Schema(description = "잔소리명", example = "잔소리명") String name,
             @Schema(description = "잔소리 템플릿 이모지 URL", example = "https://example.com/emoji.png") String emojiUrl) {
 
         public static RetrieveTaskFeedbackTemplateDto from(TaskFeedbackTemplateDto template) {
             return new RetrieveTaskFeedbackTemplateDto(
-                    template.id(), template.language(), template.message(), template.emojiUrl());
+                    template.id(), template.language(), template.name(), template.emojiUrl());
         }
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveReceivedDowithTaskFeedbacksResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveReceivedDowithTaskFeedbacksResDto.java
@@ -46,12 +46,12 @@ public record RetrieveReceivedDowithTaskFeedbacksResDto(
     public record ReceivedFeedbackTemplateDto(
             @Schema(description = "잔소리 템플릿 ID", example = "1") Long id,
             @Schema(description = "잔소리 템플릿 언어", example = "ko") CountryCode language,
-            @Schema(description = "잔소리 템플릿 메시지", example = "잔소리 템플릿 메시지") String message,
+            @Schema(description = "잔소리명", example = "잔소리명") String name,
             @Schema(description = "잔소리 템플릿 이모지 URL", example = "https://example.com/emoji.png") String emojiUrl) {
 
         public static ReceivedFeedbackTemplateDto from(TaskFeedbackTemplateDto template) {
             return new ReceivedFeedbackTemplateDto(
-                    template.id(), template.language(), template.message(), template.emojiUrl());
+                    template.id(), template.language(), template.name(), template.emojiUrl());
         }
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveSentDowithTaskFeedbacksResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveSentDowithTaskFeedbacksResDto.java
@@ -46,12 +46,12 @@ public record RetrieveSentDowithTaskFeedbacksResDto(
     public record SentFeedbackTemplateDto(
             @Schema(description = "잔소리 템플릿 ID", example = "1") Long id,
             @Schema(description = "잔소리 템플릿 언어", example = "ko") CountryCode language,
-            @Schema(description = "잔소리 템플릿 메시지", example = "잔소리 템플릿 메시지") String message,
+            @Schema(description = "잔소리명", example = "잔소리명") String name,
             @Schema(description = "잔소리 템플릿 이모지 URL", example = "https://example.com/emoji.png") String emojiUrl) {
 
         public static SentFeedbackTemplateDto from(TaskFeedbackTemplateDto template) {
             return new SentFeedbackTemplateDto(
-                    template.id(), template.language(), template.message(), template.emojiUrl());
+                    template.id(), template.language(), template.name(), template.emojiUrl());
         }
     }
 }

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/feedback/FeedbackIntegrationTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/feedback/FeedbackIntegrationTest.java
@@ -148,6 +148,7 @@ public class FeedbackIntegrationTest extends AbstractIntegrationTest {
         RetrieveTaskFeedbackDto feedback = result.feedbacks().get(0);
         assertThat(feedback.dowithTaskId()).isEqualTo(dowithTask.getId());
         assertThat(feedback.taskFeedbackTemplate().id()).isEqualTo(template1.getId());
+        assertThat(feedback.taskFeedbackTemplate().name()).isEqualTo(templateMessage1.getName());
         assertThat(feedback.isChecked()).isFalse();
     }
 
@@ -184,6 +185,7 @@ public class FeedbackIntegrationTest extends AbstractIntegrationTest {
         RetrieveTaskFeedbackDto feedback = result.feedbacks().get(0);
         assertThat(feedback.dowithTaskId()).isEqualTo(dowithTask.getId());
         assertThat(feedback.taskFeedbackTemplate().id()).isEqualTo(template1.getId());
+        assertThat(feedback.taskFeedbackTemplate().name()).isEqualTo(templateMessage1.getName());
     }
 
     @Test
@@ -206,6 +208,7 @@ public class FeedbackIntegrationTest extends AbstractIntegrationTest {
         assertThat(feedback.dowithTaskId()).isEqualTo(dowithTask.getId());
         assertThat(feedback.dowithTaskStatus()).isEqualTo(DowithTaskStatus.WAIT);
         assertThat(feedback.taskFeedbackTemplate().id()).isEqualTo(template1.getId());
+        assertThat(feedback.taskFeedbackTemplate().name()).isEqualTo(templateMessage1.getName());
         assertThat(feedback.dowithTaskTitle()).isEqualTo("테스트 태스크");
     }
 
@@ -229,6 +232,7 @@ public class FeedbackIntegrationTest extends AbstractIntegrationTest {
         assertThat(feedback.dowithTaskId()).isEqualTo(dowithTask.getId());
         assertThat(feedback.receivedAt()).isNotNull();
         assertThat(feedback.taskFeedbackTemplate().id()).isEqualTo(template1.getId());
+        assertThat(feedback.taskFeedbackTemplate().name()).isEqualTo(templateMessage1.getName());
         assertThat(feedback.dowithTaskTitle()).isEqualTo("테스트 태스크");
     }
 


### PR DESCRIPTION
## PR 체크리스트

Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [ ] 모든 Test 코드를 실행하여 PASS했나요?
- [ ] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

PR의 타입을 체크해주세요

- [x] 버그 픽스 - 이슈 링크 :
- [ ] 신규 기능 개발
- [ ] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [ ] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타

## 백로그 및 이슈 링크

- 링크 :

## 변경된 사항

### 잔소리 조회 3개 API 템플릿 응답 필드 수정

- `GET /api/v1/feedbacks/dowith-task/{id}` — 템플릿 DTO의 `message` → `name`
- `GET /api/v1/feedbacks/received` — 템플릿 DTO의 `message` → `name`
- `GET /api/v1/feedbacks/send` — 템플릿 DTO의 `message` → `name`

각 응답 안의 `taskFeedbackTemplate` 객체에서 기존에 `message`(잔소리 본문)를 내려주던 것을, `TaskFeedbackTemplateMessage.name`(잔소리명) 으로 변경

### 테스트 수정

- `FeedbackIntegrationTest` — 위 3개 API 관련 테스트에 `taskFeedbackTemplate().name()` 검증 assertion 추가

## 기타 전달 사항

-