### PR TITLE
hotfix: 잔소리 가능 두윗 조회 시 내가 만든 두윗 제외

### DIFF
--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/task/service/RetrieveTaskService.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/task/service/RetrieveTaskService.java
@@ -93,7 +93,8 @@ public class RetrieveTaskService {
 
         // 1. Task 리스트 조회
         List<FeedbackAvailableDowithTasksQueryDto> feedbackAvailableDowithTasks =
-                dowithTaskQueryRepository.getFeedbackAvailableDowithTasks(pageable.getOffset(), pageable.getPageSize());
+                dowithTaskQueryRepository.getFeedbackAvailableDowithTasks(
+                        pageable.getOffset(), pageable.getPageSize(), memberId);
 
         if (feedbackAvailableDowithTasks.isEmpty()) {
             return RetrieveFeedbackAvailableDowithTasksResult.from(0L, feedbackAvailableDowithTasks);
@@ -122,6 +123,6 @@ public class RetrieveTaskService {
                 .toList();
 
         return RetrieveFeedbackAvailableDowithTasksResult.from(
-                dowithTaskQueryRepository.countFeedbackAvailableDowithTasks(), tasks);
+                dowithTaskQueryRepository.countFeedbackAvailableDowithTasks(memberId), tasks);
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/task/repository/DowithTaskQueryRepository.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/task/repository/DowithTaskQueryRepository.java
@@ -23,9 +23,10 @@ public interface DowithTaskQueryRepository {
 
     Map<Long, Long> countDowithTaskLikes(Set<Long> dowithTaskIds);
 
-    List<FeedbackAvailableDowithTasksQueryDto> getFeedbackAvailableDowithTasks(Long offset, int size);
+    List<FeedbackAvailableDowithTasksQueryDto> getFeedbackAvailableDowithTasks(
+            Long offset, int size, String excludeMemberId);
 
-    Long countFeedbackAvailableDowithTasks();
+    Long countFeedbackAvailableDowithTasks(String excludeMemberId);
 
     List<FailedDowithTaskCountQueryDto> getFailedTaskCountsByMember(
             LocalDateTime aggregationStartDateTime, LocalDateTime aggregationEndDateTime);

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/task/query/DowithTaskQueryRespositoryImpl.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/task/query/DowithTaskQueryRespositoryImpl.java
@@ -179,7 +179,8 @@ public class DowithTaskQueryRespositoryImpl implements DowithTaskQueryRepository
     }
 
     @Override
-    public List<FeedbackAvailableDowithTasksQueryDto> getFeedbackAvailableDowithTasks(Long offset, int size) {
+    public List<FeedbackAvailableDowithTasksQueryDto> getFeedbackAvailableDowithTasks(
+            Long offset, int size, String excludeMemberId) {
         return queryFactory
                 .select(Projections.constructor(
                         FeedbackAvailableDowithTasksQueryDto.class,
@@ -201,18 +202,18 @@ public class DowithTaskQueryRespositoryImpl implements DowithTaskQueryRepository
                 .on(memberBadge.memberId.eq(member.id).and(memberBadge.isMain.eq(Yn.TRUE)))
                 .leftJoin(badge)
                 .on(badge.id.eq(memberBadge.badge.id))
-                .where(buildFeedbackAvailableCondition())
+                .where(buildFeedbackAvailableCondition(), dowithTask.memberId.ne(excludeMemberId))
                 .offset(offset)
                 .limit(size)
                 .fetch();
     }
 
     @Override
-    public Long countFeedbackAvailableDowithTasks() {
+    public Long countFeedbackAvailableDowithTasks(String excludeMemberId) {
         return queryFactory
                 .select(dowithTask.count())
                 .from(dowithTask)
-                .where(buildFeedbackAvailableCondition())
+                .where(buildFeedbackAvailableCondition(), dowithTask.memberId.ne(excludeMemberId))
                 .fetchOne();
     }
 

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/task/RetrieveFeedbackAvailableDowithTasksIntegrationTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/task/RetrieveFeedbackAvailableDowithTasksIntegrationTest.java
@@ -53,6 +53,7 @@ public class RetrieveFeedbackAvailableDowithTasksIntegrationTest extends Abstrac
     private DowithTask taskInRange1;
     private DowithTask taskInRange2;
     private DowithTask taskInRange3;
+    private DowithTask taskMyOwnInRange;
     private DowithTask taskBoundaryExcluded;
     private DowithTask taskFutureExcluded;
     private DowithTask taskSuccessExcluded;
@@ -61,6 +62,7 @@ public class RetrieveFeedbackAvailableDowithTasksIntegrationTest extends Abstrac
     private DowithTask taskPrevDayBoundaryExcluded;
     private DowithTask taskTodayInRange;
     private DowithTask taskTodayFutureExcluded;
+    private DowithTask taskMyOwnMidnightInRange;
 
     @Override
     protected void deleteTestData() {
@@ -93,38 +95,44 @@ public class RetrieveFeedbackAvailableDowithTasksIntegrationTest extends Abstrac
         taskInRange1 =
                 DowithTask.of(otherMember.getId(), null, "inRange1", LocalDate.of(2024, 3, 1), LocalTime.of(9, 31));
         taskInRange2 =
-                DowithTask.of(requestMember.getId(), null, "inRange2", LocalDate.of(2024, 3, 1), LocalTime.of(9, 45));
+                DowithTask.of(otherMember.getId(), null, "inRange2", LocalDate.of(2024, 3, 1), LocalTime.of(9, 45));
         taskInRange3 =
-                DowithTask.of(requestMember.getId(), null, "inRange3", LocalDate.of(2024, 3, 1), LocalTime.of(10, 30));
+                DowithTask.of(otherMember.getId(), null, "inRange3", LocalDate.of(2024, 3, 1), LocalTime.of(10, 30));
+        taskMyOwnInRange = DowithTask.of(
+                requestMember.getId(), null, "myOwnInRange", LocalDate.of(2024, 3, 1), LocalTime.of(9, 50));
         taskBoundaryExcluded = DowithTask.of(
-                requestMember.getId(), null, "boundaryExcluded", LocalDate.of(2024, 3, 1), LocalTime.of(9, 30));
+                otherMember.getId(), null, "boundaryExcluded", LocalDate.of(2024, 3, 1), LocalTime.of(9, 30));
         taskFutureExcluded = DowithTask.of(
-                requestMember.getId(), null, "futureExcluded", LocalDate.of(2024, 3, 1), LocalTime.of(10, 31));
+                otherMember.getId(), null, "futureExcluded", LocalDate.of(2024, 3, 1), LocalTime.of(10, 31));
 
         taskSuccessExcluded = DowithTask.of(
-                requestMember.getId(), null, "successExcluded", LocalDate.of(2024, 3, 1), LocalTime.of(10, 0));
+                otherMember.getId(), null, "successExcluded", LocalDate.of(2024, 3, 1), LocalTime.of(10, 0));
         taskSuccessExcluded.success(List.of("https://example.com/success1.jpg"));
 
         taskPrevDayInRange = DowithTask.of(
-                requestMember.getId(), null, "prevDayInRange", LocalDate.of(2024, 3, 1), LocalTime.of(23, 40));
+                otherMember.getId(), null, "prevDayInRange", LocalDate.of(2024, 3, 1), LocalTime.of(23, 40));
         taskPrevDayBoundaryExcluded = DowithTask.of(
-                requestMember.getId(), null, "prevDayBoundaryExcluded", LocalDate.of(2024, 3, 1), LocalTime.of(23, 30));
-        taskTodayInRange = DowithTask.of(
-                requestMember.getId(), null, "todayInRange", LocalDate.of(2024, 3, 2), LocalTime.of(0, 20));
+                otherMember.getId(), null, "prevDayBoundaryExcluded", LocalDate.of(2024, 3, 1), LocalTime.of(23, 30));
+        taskTodayInRange =
+                DowithTask.of(otherMember.getId(), null, "todayInRange", LocalDate.of(2024, 3, 2), LocalTime.of(0, 20));
         taskTodayFutureExcluded = DowithTask.of(
-                requestMember.getId(), null, "todayFutureExcluded", LocalDate.of(2024, 3, 2), LocalTime.of(0, 40));
+                otherMember.getId(), null, "todayFutureExcluded", LocalDate.of(2024, 3, 2), LocalTime.of(0, 40));
+        taskMyOwnMidnightInRange = DowithTask.of(
+                requestMember.getId(), null, "myOwnMidnightInRange", LocalDate.of(2024, 3, 1), LocalTime.of(23, 35));
 
         dowithTaskJpaRepository.saveAll(List.of(
                 taskInRange1,
                 taskInRange2,
                 taskInRange3,
+                taskMyOwnInRange,
                 taskBoundaryExcluded,
                 taskFutureExcluded,
                 taskSuccessExcluded,
                 taskPrevDayInRange,
                 taskPrevDayBoundaryExcluded,
                 taskTodayInRange,
-                taskTodayFutureExcluded));
+                taskTodayFutureExcluded,
+                taskMyOwnMidnightInRange));
 
         DowithTaskFeedback feedback1 = DowithTaskFeedback.of(
                 requestMember.getId(), taskInRange1.getMemberId(), taskInRange1.getId(), template.getId());
@@ -155,6 +163,7 @@ public class RetrieveFeedbackAvailableDowithTasksIntegrationTest extends Abstrac
         assertThat(ids).contains(taskInRange1.getId(), taskInRange2.getId(), taskInRange3.getId());
         assertThat(ids)
                 .doesNotContain(
+                        taskMyOwnInRange.getId(),
                         taskBoundaryExcluded.getId(),
                         taskFutureExcluded.getId(),
                         taskSuccessExcluded.getId(),
@@ -193,11 +202,25 @@ public class RetrieveFeedbackAvailableDowithTasksIntegrationTest extends Abstrac
         assertThat(ids).contains(taskPrevDayInRange.getId(), taskTodayInRange.getId());
         assertThat(ids)
                 .doesNotContain(
+                        taskMyOwnMidnightInRange.getId(),
                         taskPrevDayBoundaryExcluded.getId(),
                         taskTodayFutureExcluded.getId(),
                         taskInRange1.getId(),
                         taskInRange2.getId(),
                         taskInRange3.getId());
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 잔소리 가능 두윗 목록 조회 - 내가 만든 두윗 제외")
+    void retrieveFeedbackAvailableDowithTasks_excludeMyOwn() throws Exception {
+        setFixedClock(LocalDateTime.of(2024, 3, 1, 10, 30, 0));
+
+        ResponsePageDto<RetrieveFeedbackAvailableDowithTasksResDto> pageResponse = requestFeedbackAvailablePage(0, 20);
+        List<Long> ids = pageResponse.data().dowithTasks().stream()
+                .map(RetrieveFeedbackAvailableDowithTaskResDto::id)
+                .toList();
+
+        assertThat(ids).doesNotContain(taskMyOwnInRange.getId());
     }
 
     @Test


### PR DESCRIPTION
## PR 체크리스트

Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [x] 모든 Test 코드를 실행하여 PASS했나요?
- [ ] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

PR의 타입을 체크해주세요

- [x] 버그 픽스 - 이슈 링크 :
- [ ] 신규 기능 개발
- [ ] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [ ] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타

## 백로그 및 이슈 링크

- 링크 :

## 변경된 사항

### 잔소리 가능 두윗 조회 시 내가 만든 두윗 제외

- `DowithTaskQueryRepository` — `getFeedbackAvailableDowithTasks`, `countFeedbackAvailableDowithTasks`에 `excludeMemberId` 파라미터 추가
- `DowithTaskQueryRespositoryImpl` — `.where()` 절에 `dowithTask.memberId.ne(excludeMemberId)` 조건 추가 (`buildFeedbackAvailableCondition`은 시간/상태 조건만 유지)
- `RetrieveTaskService` — `AuthUtil.getMemberId()`로 꺼낸 `memberId`를 두 repo 호출에 전달

### 통합 테스트 보완

- 기존 테스트 데이터의 두윗 소유자를 `otherMember`로 정리하고, `requestMember` 소유 두윗(`taskMyOwnInRange`, `taskMyOwnMidnightInRange`)을 명시적으로 추가
- 내가 만든 두윗 제외 검증 테스트 케이스 신규 추가

## 기타 전달 사항

- Swagger 응답 스펙 변경 없음 (파라미터/응답 구조 동일)
