### PR TITLE
fix: 보낸 잔소리 조회 응답에서 sender 대신 receiver 프로필 반환, 잔소리 템플릿 보여지도록 수정

### DIFF
--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveReceivedTaskFeedbackResult.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveReceivedTaskFeedbackResult.java
@@ -10,21 +10,30 @@ import java.util.List;
 public record RetrieveReceivedTaskFeedbackResult(Long totalCount, List<ReceivedTaskFeedbackDto> feedbacks) {
 
     public static RetrieveReceivedTaskFeedbackResult of(
-            Long totalCount, List<DowithTaskFeedbackQueryDto> feedbacks, List<TaskFeedbackTemplateQueryDto> templates) {
+            Long totalCount,
+            List<DowithTaskFeedbackQueryDto> feedbacks,
+            List<TaskFeedbackTemplateQueryDto> templates,
+            String receiverNickname) {
         List<ReceivedTaskFeedbackDto> feedbackDtos = feedbacks.stream()
-                .map(feedback -> new ReceivedTaskFeedbackDto(
-                        feedback.id(),
-                        feedback.dowithTaskId(),
-                        feedback.dowithTaskTitle(),
-                        feedback.senderId(),
-                        feedback.senderNickname(),
-                        feedback.senderProfileImageUrl(),
-                        feedback.isChecked(),
-                        feedback.receivedAt(),
-                        TaskFeedbackTemplateDto.from(templates.stream()
-                                .filter(template -> template.id().equals(feedback.taskFeedbackTemplateId()))
-                                .findFirst()
-                                .get())))
+                .map(feedback -> {
+                    TaskFeedbackTemplateDto template = TaskFeedbackTemplateDto.from(templates.stream()
+                            .filter(t -> t.id().equals(feedback.taskFeedbackTemplateId()))
+                            .findFirst()
+                            .get());
+                    String parsedMessage = template.message()
+                            .replace("{{receiverNickname}}", receiverNickname != null ? receiverNickname : "");
+                    return new ReceivedTaskFeedbackDto(
+                            feedback.id(),
+                            feedback.dowithTaskId(),
+                            feedback.dowithTaskTitle(),
+                            feedback.senderId(),
+                            feedback.senderNickname(),
+                            feedback.senderProfileImageUrl(),
+                            feedback.isChecked(),
+                            feedback.receivedAt(),
+                            parsedMessage,
+                            template);
+                })
                 .toList();
 
         return new RetrieveReceivedTaskFeedbackResult(totalCount, feedbackDtos);
@@ -40,5 +49,6 @@ public record RetrieveReceivedTaskFeedbackResult(Long totalCount, List<ReceivedT
                     String senderProfileImageUrl,
             @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
             @Schema(description = "잔소리 받은 시각") LocalDateTime receivedAt,
+            @Schema(description = "받는사람(나) 닉네임이 치환된 잔소리 메시지", example = "홍길동 오늘도 달렸나요?") String parsedMessage,
             @Schema(description = "잔소리 템플릿") TaskFeedbackTemplateDto taskFeedbackTemplate) {}
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveSentTaskFeedbackResult.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveSentTaskFeedbackResult.java
@@ -14,19 +14,27 @@ public record RetrieveSentTaskFeedbackResult(Long totalCount, List<SentTaskFeedb
             List<SentDowithTaskFeedbackQueryDto> feedbacks,
             List<TaskFeedbackTemplateQueryDto> templates) {
         List<SentTaskFeedbackDto> feedbackDtos = feedbacks.stream()
-                .map(feedback -> new SentTaskFeedbackDto(
-                        feedback.id(),
-                        feedback.dowithTaskId(),
-                        feedback.dowithTaskTitle(),
-                        feedback.receiverId(),
-                        feedback.receiverNickname(),
-                        feedback.receiverProfileImageUrl(),
-                        feedback.isChecked(),
-                        feedback.dowithTaskStatus(),
-                        TaskFeedbackTemplateDto.from(templates.stream()
-                                .filter(template -> template.id().equals(feedback.taskFeedbackTemplateId()))
-                                .findFirst()
-                                .get())))
+                .map(feedback -> {
+                    TaskFeedbackTemplateDto template = TaskFeedbackTemplateDto.from(templates.stream()
+                            .filter(t -> t.id().equals(feedback.taskFeedbackTemplateId()))
+                            .findFirst()
+                            .get());
+                    String parsedMessage = template.message()
+                            .replace(
+                                    "{{receiverNickname}}",
+                                    feedback.receiverNickname() != null ? feedback.receiverNickname() : "");
+                    return new SentTaskFeedbackDto(
+                            feedback.id(),
+                            feedback.dowithTaskId(),
+                            feedback.dowithTaskTitle(),
+                            feedback.receiverId(),
+                            feedback.receiverNickname(),
+                            feedback.receiverProfileImageUrl(),
+                            feedback.isChecked(),
+                            feedback.dowithTaskStatus(),
+                            parsedMessage,
+                            template);
+                })
                 .toList();
 
         return new RetrieveSentTaskFeedbackResult(totalCount, feedbackDtos);
@@ -42,5 +50,6 @@ public record RetrieveSentTaskFeedbackResult(Long totalCount, List<SentTaskFeedb
                     String receiverProfileImageUrl,
             @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
             @Schema(description = "잔소리 대상 두윗모드 Task 상태", example = "WAIT") DowithTaskStatus dowithTaskStatus,
+            @Schema(description = "받는사람 닉네임이 치환된 잔소리 메시지", example = "홍길동 오늘도 달렸나요?") String parsedMessage,
             @Schema(description = "잔소리 템플릿") TaskFeedbackTemplateDto taskFeedbackTemplate) {}
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveSentTaskFeedbackResult.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveSentTaskFeedbackResult.java
@@ -18,9 +18,9 @@ public record RetrieveSentTaskFeedbackResult(Long totalCount, List<SentTaskFeedb
                         feedback.id(),
                         feedback.dowithTaskId(),
                         feedback.dowithTaskTitle(),
-                        feedback.senderId(),
-                        feedback.senderNickname(),
-                        feedback.senderProfileImageUrl(),
+                        feedback.receiverId(),
+                        feedback.receiverNickname(),
+                        feedback.receiverProfileImageUrl(),
                         feedback.isChecked(),
                         feedback.dowithTaskStatus(),
                         TaskFeedbackTemplateDto.from(templates.stream()
@@ -36,10 +36,10 @@ public record RetrieveSentTaskFeedbackResult(Long totalCount, List<SentTaskFeedb
             @Schema(description = "잔소리 ID", example = "1") Long id,
             @Schema(description = "두윗모드 Task ID", example = "12345") Long dowithTaskId,
             @Schema(description = "두윗모드 Task 제목", example = "저녁 러닝하기") String dowithTaskTitle,
-            @Schema(description = "잔소리 보낸사람 ID", example = "(TSID)") String senderId,
-            @Schema(description = "잔소리 보낸사람 닉네임", example = "feedbackSender123") String senderNickname,
-            @Schema(description = "잔소리 보낸사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
-                    String senderProfileImageUrl,
+            @Schema(description = "잔소리 받는사람 ID", example = "(TSID)") String receiverId,
+            @Schema(description = "잔소리 받는사람 닉네임", example = "feedbackReceiver123") String receiverNickname,
+            @Schema(description = "잔소리 받는사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+                    String receiverProfileImageUrl,
             @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
             @Schema(description = "잔소리 대상 두윗모드 Task 상태", example = "WAIT") DowithTaskStatus dowithTaskStatus,
             @Schema(description = "잔소리 템플릿") TaskFeedbackTemplateDto taskFeedbackTemplate) {}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/service/RetrieveTaskFeedbackService.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/service/RetrieveTaskFeedbackService.java
@@ -1,6 +1,8 @@
 package com.LetMeDoWith.LetMeDoWith.application.feedback.service;
 
 import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.*;
+import com.LetMeDoWith.LetMeDoWith.common.exception.RestApiException;
+import com.LetMeDoWith.LetMeDoWith.common.exception.status.FailResponseStatus;
 import com.LetMeDoWith.LetMeDoWith.common.util.AuthUtil;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.DowithTaskFeedbackQueryRepository;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.TaskFeedbackTemplateQueryRepository;
@@ -8,6 +10,7 @@ import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.AggregateTaskF
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.DowithTaskFeedbackQueryDto;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.SentDowithTaskFeedbackQueryDto;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.TaskFeedbackTemplateQueryDto;
+import com.LetMeDoWith.LetMeDoWith.domain.member.repository.MemberRepository;
 import com.LetMeDoWith.LetMeDoWith.domain.task.enums.CountryCode;
 import jakarta.annotation.Nullable;
 import java.util.List;
@@ -21,6 +24,7 @@ public class RetrieveTaskFeedbackService {
 
     private final DowithTaskFeedbackQueryRepository dowithTaskFeedbackQueryRepository;
     private final TaskFeedbackTemplateQueryRepository taskFeedbackTemplateQueryRepository;
+    private final MemberRepository memberRepository;
 
     /**
      * DowithTask가 받은 잔소리 목록 조회
@@ -62,13 +66,18 @@ public class RetrieveTaskFeedbackService {
 
         String memberId = AuthUtil.getMemberId();
 
+        String receiverNickname = memberRepository
+                .getNormalStatusMember(memberId)
+                .orElseThrow(() -> new RestApiException(FailResponseStatus.MEMBER_NOT_EXIST))
+                .getNickname();
+
         Long totalCount = dowithTaskFeedbackQueryRepository.countFeedbacksByReceiverId(memberId);
         List<DowithTaskFeedbackQueryDto> feedbackDtos = dowithTaskFeedbackQueryRepository.getFeedbacksByReceiverId(
                 memberId, pageable.getOffset(), pageable.getPageSize());
         List<TaskFeedbackTemplateQueryDto> feedbackTemplates =
                 taskFeedbackTemplateQueryRepository.getAllTaskFeedbackTemplates(CountryCode.KR);
 
-        return RetrieveReceivedTaskFeedbackResult.of(totalCount, feedbackDtos, feedbackTemplates);
+        return RetrieveReceivedTaskFeedbackResult.of(totalCount, feedbackDtos, feedbackTemplates, receiverNickname);
     }
 
     /**

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/feedback/repository/dto/SentDowithTaskFeedbackQueryDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/domain/feedback/repository/dto/SentDowithTaskFeedbackQueryDto.java
@@ -9,9 +9,9 @@ public record SentDowithTaskFeedbackQueryDto(
         @Schema(description = "두윗모드 Task ID", example = "12345") Long dowithTaskId,
         @Schema(description = "두윗모드 Task 제목", example = "저녁 러닝하기") String dowithTaskTitle,
         @Schema(description = "잔소리 템플릿 ID", example = "67890") Long taskFeedbackTemplateId,
-        @Schema(description = "잔소리 보낸사람 ID", example = "(TSID)") String senderId,
-        @Schema(description = "잔소리 보낸사람 닉네임", example = "feedbackSender123") String senderNickname,
-        @Schema(description = "잔소리 보낸사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
-                String senderProfileImageUrl,
+        @Schema(description = "잔소리 받는사람 ID", example = "(TSID)") String receiverId,
+        @Schema(description = "잔소리 받는사람 닉네임", example = "feedbackReceiver123") String receiverNickname,
+        @Schema(description = "잔소리 받는사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+                String receiverProfileImageUrl,
         @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
         @Schema(description = "잔소리 대상 두윗모드 Task 상태", example = "WAIT") DowithTaskStatus dowithTaskStatus) {}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/feedback/query/DowithTaskFeedbackQueryRepositoryImpl.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/infrastructure/feedback/query/DowithTaskFeedbackQueryRepositoryImpl.java
@@ -101,7 +101,7 @@ public class DowithTaskFeedbackQueryRepositoryImpl implements DowithTaskFeedback
                         dowithTask.status))
                 .from(dowithTaskFeedback)
                 .leftJoin(member)
-                .on(dowithTaskFeedback.senderMemberId.eq(member.id))
+                .on(dowithTaskFeedback.receiverMemberId.eq(member.id))
                 .leftJoin(dowithTask)
                 .on(dowithTaskFeedback.dowithTaskId.eq(dowithTask.id))
                 .where(dowithTaskFeedback.senderMemberId.eq(senderId))

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveReceivedDowithTaskFeedbacksResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveReceivedDowithTaskFeedbacksResDto.java
@@ -27,6 +27,7 @@ public record RetrieveReceivedDowithTaskFeedbacksResDto(
                     String senderProfileImageUrl,
             @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
             @Schema(description = "잔소리 받은 시각") LocalDateTime receivedAt,
+            @Schema(description = "받는사람(나) 닉네임이 치환된 잔소리 메시지", example = "홍길동 오늘도 달렸나요?") String parsedMessage,
             @Schema(description = "잔소리 템플릿") ReceivedFeedbackTemplateDto taskFeedbackTemplate) {
 
         public static ReceivedFeedbackDto from(ReceivedTaskFeedbackDto feedback) {
@@ -39,6 +40,7 @@ public record RetrieveReceivedDowithTaskFeedbacksResDto(
                     feedback.senderProfileImageUrl(),
                     feedback.isChecked(),
                     feedback.receivedAt(),
+                    feedback.parsedMessage(),
                     ReceivedFeedbackTemplateDto.from(feedback.taskFeedbackTemplate()));
         }
     }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveSentDowithTaskFeedbacksResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveSentDowithTaskFeedbacksResDto.java
@@ -21,10 +21,10 @@ public record RetrieveSentDowithTaskFeedbacksResDto(
             @Schema(description = "잔소리 ID", example = "1") Long id,
             @Schema(description = "두윗모드 Task ID", example = "12345") Long dowithTaskId,
             @Schema(description = "두윗모드 Task 제목", example = "저녁 러닝하기") String dowithTaskTitle,
-            @Schema(description = "잔소리 보낸사람 ID", example = "(TSID)") String senderId,
-            @Schema(description = "잔소리 보낸사람 닉네임", example = "feedbackSender123") String senderNickname,
-            @Schema(description = "잔소리 보낸사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
-                    String senderProfileImageUrl,
+            @Schema(description = "잔소리 받는사람 ID", example = "(TSID)") String receiverId,
+            @Schema(description = "잔소리 받는사람 닉네임", example = "feedbackReceiver123") String receiverNickname,
+            @Schema(description = "잔소리 받는사람 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+                    String receiverProfileImageUrl,
             @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
             @Schema(description = "잔소리 대상 두윗모드 Task 상태", example = "WAIT") DowithTaskStatus dowithTaskStatus,
             @Schema(description = "잔소리 템플릿") SentFeedbackTemplateDto taskFeedbackTemplate) {
@@ -34,9 +34,9 @@ public record RetrieveSentDowithTaskFeedbacksResDto(
                     feedback.id(),
                     feedback.dowithTaskId(),
                     feedback.dowithTaskTitle(),
-                    feedback.senderId(),
-                    feedback.senderNickname(),
-                    feedback.senderProfileImageUrl(),
+                    feedback.receiverId(),
+                    feedback.receiverNickname(),
+                    feedback.receiverProfileImageUrl(),
                     feedback.isChecked(),
                     feedback.dowithTaskStatus(),
                     SentFeedbackTemplateDto.from(feedback.taskFeedbackTemplate()));

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveSentDowithTaskFeedbacksResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveSentDowithTaskFeedbacksResDto.java
@@ -27,6 +27,7 @@ public record RetrieveSentDowithTaskFeedbacksResDto(
                     String receiverProfileImageUrl,
             @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
             @Schema(description = "잔소리 대상 두윗모드 Task 상태", example = "WAIT") DowithTaskStatus dowithTaskStatus,
+            @Schema(description = "받는사람 닉네임이 치환된 잔소리 메시지", example = "홍길동 오늘도 달렸나요?") String parsedMessage,
             @Schema(description = "잔소리 템플릿") SentFeedbackTemplateDto taskFeedbackTemplate) {
 
         public static SentFeedbackDto from(SentTaskFeedbackDto feedback) {
@@ -39,6 +40,7 @@ public record RetrieveSentDowithTaskFeedbacksResDto(
                     feedback.receiverProfileImageUrl(),
                     feedback.isChecked(),
                     feedback.dowithTaskStatus(),
+                    feedback.parsedMessage(),
                     SentFeedbackTemplateDto.from(feedback.taskFeedbackTemplate()));
         }
     }


### PR DESCRIPTION
## PR 체크리스트

Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [x] 모든 Test 코드를 실행하여 PASS했나요?
- [x] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

PR의 타입을 체크해주세요

- [x] 버그 픽스 - 이슈 링크 :
- [ ] 신규 기능 개발
- [x] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [ ] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타

## 백로그 및 이슈 링크

- 링크 : TAS-746

## 변경된 사항

### 보낸 잔소리 조회 응답 필드 수정

- `GET /api/v1/feedbacks/send` 응답에서 잔소리를 받은 사람(receiver)의 프로필 정보를 반환하도록 수정
- `getFeedbacksBySenderId` 쿼리의 member join 조건 `senderMemberId` → `receiverMemberId`로 변경
- `senderId` / `senderNickname` / `senderProfileImageUrl` → `receiverId` / `receiverNickname` / `receiverProfileImageUrl` 필드명 변경 (QueryDto, Result DTO, ResDto 전 계층)

### 보낸/받은 잔소리 응답에 parsedMessage 필드 추가

- 잔소리 템플릿 메시지의 `{{receiverNickname}}` 플레이스홀더를 실제 닉네임으로 치환한 `parsedMessage` 필드 추가
- 보낸 잔소리(`GET /api/v1/feedbacks/send`): `receiverNickname`(실제 받는 사람)으로 치환
- 받은 잔소리(`GET /api/v1/feedbacks/received`): 현재 로그인 사용자(나)의 닉네임으로 치환
- `RetrieveTaskFeedbackService`에 `MemberRepository` 주입하여 내 닉네임 조회

## 기타 전달 사항

- API 응답 필드명이 변경되므로 클라이언트 측 수정 필요 (`senderId` → `receiverId` 등)
- `parsedMessage`는 신규 필드로 추가됨