### PR TITLE
feat: 받은 잔소리 조회 응답에 딥링크 추가

### DIFF
--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveReceivedTaskFeedbackResult.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/feedback/dto/RetrieveReceivedTaskFeedbackResult.java
@@ -1,5 +1,6 @@
 package com.LetMeDoWith.LetMeDoWith.application.feedback.dto;
 
+import com.LetMeDoWith.LetMeDoWith.application.notification.deeplink.DeepLinkFactory;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.DowithTaskFeedbackQueryDto;
 import com.LetMeDoWith.LetMeDoWith.domain.feedback.repository.dto.TaskFeedbackTemplateQueryDto;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,6 +23,7 @@ public record RetrieveReceivedTaskFeedbackResult(Long totalCount, List<ReceivedT
                             .get());
                     String parsedMessage = template.message()
                             .replace("{{receiverNickname}}", receiverNickname != null ? receiverNickname : "");
+                    String deepLink = DeepLinkFactory.home(feedback.receivedAt().toLocalDate());
                     return new ReceivedTaskFeedbackDto(
                             feedback.id(),
                             feedback.dowithTaskId(),
@@ -32,7 +34,8 @@ public record RetrieveReceivedTaskFeedbackResult(Long totalCount, List<ReceivedT
                             feedback.isChecked(),
                             feedback.receivedAt(),
                             parsedMessage,
-                            template);
+                            template,
+                            deepLink);
                 })
                 .toList();
 
@@ -50,5 +53,6 @@ public record RetrieveReceivedTaskFeedbackResult(Long totalCount, List<ReceivedT
             @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
             @Schema(description = "잔소리 받은 시각") LocalDateTime receivedAt,
             @Schema(description = "받는사람(나) 닉네임이 치환된 잔소리 메시지", example = "홍길동 오늘도 달렸나요?") String parsedMessage,
-            @Schema(description = "잔소리 템플릿") TaskFeedbackTemplateDto taskFeedbackTemplate) {}
+            @Schema(description = "잔소리 템플릿") TaskFeedbackTemplateDto taskFeedbackTemplate,
+            @Schema(description = "딥링크", example = "letmedowith://home?date=2026-07-19") String deepLink) {}
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/application/notification/deeplink/DeepLinkFactory.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/application/notification/deeplink/DeepLinkFactory.java
@@ -1,0 +1,16 @@
+package com.LetMeDoWith.LetMeDoWith.application.notification.deeplink;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class DeepLinkFactory {
+
+    private static final String SCHEME = "letmedowith://";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    public static String home(LocalDate date) {
+        return SCHEME + "home?date=" + date.format(DATE_FORMATTER);
+    }
+}

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveReceivedDowithTaskFeedbacksResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/RetrieveReceivedDowithTaskFeedbacksResDto.java
@@ -28,7 +28,8 @@ public record RetrieveReceivedDowithTaskFeedbacksResDto(
             @Schema(description = "잔소리 확인여부", example = "false") Boolean isChecked,
             @Schema(description = "잔소리 받은 시각") LocalDateTime receivedAt,
             @Schema(description = "받는사람(나) 닉네임이 치환된 잔소리 메시지", example = "홍길동 오늘도 달렸나요?") String parsedMessage,
-            @Schema(description = "잔소리 템플릿") ReceivedFeedbackTemplateDto taskFeedbackTemplate) {
+            @Schema(description = "잔소리 템플릿") ReceivedFeedbackTemplateDto taskFeedbackTemplate,
+            @Schema(description = "딥링크", example = "letmedowith://home?date=2026-07-19") String deepLink) {
 
         public static ReceivedFeedbackDto from(ReceivedTaskFeedbackDto feedback) {
             return new ReceivedFeedbackDto(
@@ -41,7 +42,8 @@ public record RetrieveReceivedDowithTaskFeedbacksResDto(
                     feedback.isChecked(),
                     feedback.receivedAt(),
                     feedback.parsedMessage(),
-                    ReceivedFeedbackTemplateDto.from(feedback.taskFeedbackTemplate()));
+                    ReceivedFeedbackTemplateDto.from(feedback.taskFeedbackTemplate()),
+                    feedback.deepLink());
         }
     }
 


### PR DESCRIPTION
## PR 체크리스트

Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [ ] 모든 Test 코드를 실행하여 PASS했나요?
- [x] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

PR의 타입을 체크해주세요

- [ ] 버그 픽스 - 이슈 링크 :
- [ ] 신규 기능 개발
- [x] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [ ] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타

## 백로그 및 이슈 링크

- 링크 : TAS-954

## 변경된 사항

### 사항1

- 받은 잔소리 목록 조회 응답(`ReceivedFeedbackDto`)에 `deepLink` 필드 추가
- 앱에서 잔소리를 눌렀을 때 해당 날짜의 홈 화면으로 이동할 수 있도록 `letmedowith://home?date=YYYY-MM-DD` 형식으로 내려줌

### 사항2

- 딥링크 조립 로직을 `application/notification/deeplink/DeepLinkFactory`로 분리
- 기존에는 `NotificationTemplate.appDeepLink`처럼 static 문자열만 다뤘는데, 동적 파라미터(date)가 필요한 첫 케이스라 factory가 route/포맷을 소유하고 호출부(feedback 도메인)는 값만 주입하는 방식으로 설계

## 기타 전달 사항

- `RetrieveFeedbackIntegrationTest` 로컬 실행 시 4개 테스트가 `FirebaseMessagingException: SenderId mismatch`로 실패함. 원인은 `CreateDowithTaskFeedbackService`가 테스트 픽스처 생성 중 FCM push를 실제로 호출하면서 나는 로컬 환경(FCM 자격증명) 이슈로, 이번 딥링크 변경과 무관한 기존 실패로 보임 (변경 전 코드에서도 동일하게 재현됨). 확인 부탁드립니다.