### PR TITLE
refactor: 잔소리 템플릿명 nameTokens 분리 + 로컬 시드 데이터 추가

### DIFF
--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/FeedbackTemplateDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/feedback/dto/FeedbackTemplateDto.java
@@ -3,15 +3,25 @@ package com.LetMeDoWith.LetMeDoWith.presentation.feedback.dto;
 import com.LetMeDoWith.LetMeDoWith.application.feedback.dto.TaskFeedbackTemplateDto;
 import com.LetMeDoWith.LetMeDoWith.domain.task.enums.CountryCode;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Arrays;
+import java.util.List;
 
 public record FeedbackTemplateDto(
         @Schema(description = "템플릿 ID") Long id,
         @Schema(description = "템플릿 언어") CountryCode language,
-        @Schema(description = "템플릿명") String name,
+        @Schema(description = "템플릿명 줄바꿈 단위 목록", example = "[\"아직도\", \"안하네\"]") List<String> nameTokens,
         @Schema(description = "템플릿 메시지") String message,
         @Schema(description = "템플릿 이모지 URL") String emojiUrl) {
     public static FeedbackTemplateDto from(TaskFeedbackTemplateDto template) {
         return new FeedbackTemplateDto(
-                template.id(), template.language(), template.name(), template.message(), template.emojiUrl());
+                template.id(),
+                template.language(),
+                splitNameTokens(template.name()),
+                template.message(),
+                template.emojiUrl());
+    }
+
+    private static List<String> splitNameTokens(String name) {
+        return Arrays.stream(name.split("\\|")).map(String::trim).toList();
     }
 }

--- a/src/main/resources/db/migration/V0.0.6__insert_feedback_template_test_data.sql
+++ b/src/main/resources/db/migration/V0.0.6__insert_feedback_template_test_data.sql
@@ -1,19 +1,22 @@
--- 잔소리 템플릿 테스트 데이터 (id=2~5)
+-- 잔소리 템플릿 테스트 데이터 초기화 후 id=1~4 순서로 재적재
+TRUNCATE TABLE task_feedback_template_message;
+TRUNCATE TABLE task_feedback_template;
+
 INSERT INTO task_feedback_template (id, emoji_url, title, description, is_active, notification_template_code,
                                     created_at, updated_at, created_by, updated_by)
-VALUES (2, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPLATE_1.png',
+VALUES (1, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPLATE_1.png',
         'FEEDBACK_TEMPLATE_A', '{{receiverNickname}}님아;; 아직도 안했구나?🤨', 'Y', 'FEEDBACK_RECEIVED_1', NOW(), NOW(), 'system', 'system'),
-       (3, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPLATE_2.png',
+       (2, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPLATE_2.png',
         'FEEDBACK_TEMPLATE_B', '혹시 잡도리 수집중이니?🤓', 'Y', 'FEEDBACK_RECEIVED_2', NOW(), NOW(), 'system', 'system'),
-       (4, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPLATE_3.png',
+       (3, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPLATE_3.png',
         'FEEDBACK_TEMPLATE_C', '{{receiverNickname}}, 발등에 불 떨어지고 나서야 하려고?🔥', 'Y', 'FEEDBACK_RECEIVED_3', NOW(), NOW(), 'system', 'system'),
-       (5, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPL_4.png',
+       (4, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPL_4.png',
         'FEEDBACK_TEMPLATE_D', '님 그러다 또 후회함😕', 'Y', 'FEEDBACK_RECEIVED_4', NOW(), NOW(), 'system', 'system');
 
--- 잔소리 템플릿 메시지 테스트 데이터 (id=2~5, name은 줄바꿈 단위를 "|"로 구분)
+-- 잔소리 템플릿 메시지 테스트 데이터 (id=1~4, name은 줄바꿈 단위를 "|"로 구분)
 INSERT INTO task_feedback_template_message (id, task_feedback_template_id, name, message, language,
                                             created_at, updated_at, created_by, updated_by)
-VALUES (2, 2, '아직도|안하네', '{{receiverNickname}}님아;; 아직도 안했구나?🤨', 'KR', NOW(), NOW(), 'system', 'system'),
-       (3, 3, '잡도리|수집중', '혹시 잡도리 수집중이니?🤓', 'KR', NOW(), NOW(), 'system', 'system'),
-       (4, 4, '발등|튀김됨', '{{receiverNickname}}, 발등에 불 떨어지고 나서야 하려고?🔥', 'KR', NOW(), NOW(), 'system', 'system'),
-       (5, 5, '님 또|후회함', '님 그러다 또 후회함😕', 'KR', NOW(), NOW(), 'system', 'system');
+VALUES (1, 1, '아직도|안하네', '{{receiverNickname}}님아;; 아직도 안했구나?🤨', 'KR', NOW(), NOW(), 'system', 'system'),
+       (2, 2, '잡도리|수집중', '혹시 잡도리 수집중이니?🤓', 'KR', NOW(), NOW(), 'system', 'system'),
+       (3, 3, '발등|튀김됨', '{{receiverNickname}}, 발등에 불 떨어지고 나서야 하려고?🔥', 'KR', NOW(), NOW(), 'system', 'system'),
+       (4, 4, '님 또|후회함', '님 그러다 또 후회함😕', 'KR', NOW(), NOW(), 'system', 'system');

--- a/src/main/resources/db/migration/V0.0.6__insert_feedback_template_test_data.sql
+++ b/src/main/resources/db/migration/V0.0.6__insert_feedback_template_test_data.sql
@@ -1,0 +1,19 @@
+-- 잔소리 템플릿 테스트 데이터 (id=2~5)
+INSERT INTO task_feedback_template (id, emoji_url, title, description, is_active, notification_template_code,
+                                    created_at, updated_at, created_by, updated_by)
+VALUES (2, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPLATE_1.png',
+        'FEEDBACK_TEMPLATE_A', '{{receiverNickname}}님아;; 아직도 안했구나?🤨', 'Y', 'FEEDBACK_RECEIVED_1', NOW(), NOW(), 'system', 'system'),
+       (3, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPLATE_2.png',
+        'FEEDBACK_TEMPLATE_B', '혹시 잡도리 수집중이니?🤓', 'Y', 'FEEDBACK_RECEIVED_2', NOW(), NOW(), 'system', 'system'),
+       (4, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPLATE_3.png',
+        'FEEDBACK_TEMPLATE_C', '{{receiverNickname}}, 발등에 불 떨어지고 나서야 하려고?🔥', 'Y', 'FEEDBACK_RECEIVED_3', NOW(), NOW(), 'system', 'system'),
+       (5, 'https://letmedowith-dev.s3.ap-northeast-2.amazonaws.com/static/images/feedback_templates/FEEDBACK_TEMPL_4.png',
+        'FEEDBACK_TEMPLATE_D', '님 그러다 또 후회함😕', 'Y', 'FEEDBACK_RECEIVED_4', NOW(), NOW(), 'system', 'system');
+
+-- 잔소리 템플릿 메시지 테스트 데이터 (id=2~5, name은 줄바꿈 단위를 "|"로 구분)
+INSERT INTO task_feedback_template_message (id, task_feedback_template_id, name, message, language,
+                                            created_at, updated_at, created_by, updated_by)
+VALUES (2, 2, '아직도|안하네', '{{receiverNickname}}님아;; 아직도 안했구나?🤨', 'KR', NOW(), NOW(), 'system', 'system'),
+       (3, 3, '잡도리|수집중', '혹시 잡도리 수집중이니?🤓', 'KR', NOW(), NOW(), 'system', 'system'),
+       (4, 4, '발등|튀김됨', '{{receiverNickname}}, 발등에 불 떨어지고 나서야 하려고?🔥', 'KR', NOW(), NOW(), 'system', 'system'),
+       (5, 5, '님 또|후회함', '님 그러다 또 후회함😕', 'KR', NOW(), NOW(), 'system', 'system');

--- a/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/feedback/RetrieveFeedbackIntegrationTest.java
+++ b/src/test/java/com/LetMeDoWith/LetMeDoWith/integration/feedback/RetrieveFeedbackIntegrationTest.java
@@ -145,7 +145,7 @@ public class RetrieveFeedbackIntegrationTest extends AbstractIntegrationTest {
                 .filter(t -> t.id().equals(template1.getId()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("템플릿1 결과 없음"));
-        assertThat(dto1.name()).isEqualTo(templateMessage1.getName());
+        assertThat(dto1.nameTokens()).containsExactly(templateMessage1.getName());
         assertThat(dto1.message()).isEqualTo(templateMessage1.getMessage());
         assertThat(dto1.emojiUrl()).isEqualTo(template1.getEmojiUrl());
 
@@ -153,7 +153,7 @@ public class RetrieveFeedbackIntegrationTest extends AbstractIntegrationTest {
                 .filter(t -> t.id().equals(template2.getId()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("템플릿2 결과 없음"));
-        assertThat(dto2.name()).isEqualTo(templateMessage2.getName());
+        assertThat(dto2.nameTokens()).containsExactly(templateMessage2.getName());
         assertThat(dto2.message()).isEqualTo(templateMessage2.getMessage());
         assertThat(dto2.emojiUrl()).isEqualTo(template2.getEmojiUrl());
     }


### PR DESCRIPTION
## PR 체크리스트

Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [ ] 모든 Test 코드를 실행하여 PASS했나요? (아래 기타 전달 사항 참고)
- [x] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

PR의 타입을 체크해주세요

- [ ] 버그 픽스 - 이슈 링크 :
- [ ] 신규 기능 개발
- [ ] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [x] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타

## 백로그 및 이슈 링크

- 링크 :

## 변경된 사항

### 잔소리 템플릿명 필드 분리

- `FeedbackTemplateDto.name`(String)을 제거하고 `nameTokens`(List\<String\>)로 대체
- feed 화면과 dowith task 화면이 `GET /feedbacks/templates` 응답을 함께 쓰면서, feed는 줄바꿈이 필요하고 dowith task는 필요하지 않은 문제를 `name`에 `\n`을 직접 심는 방식 대신 서버가 `"|"` 구분자로 토큰화해 배열로 내려주는 방식으로 해결
- 클라이언트는 필요에 따라 `nameTokens`를 스페이스(한 줄) 또는 개행(여러 줄)으로 join해서 사용

### 로컬 템플릿 시드 데이터 추가

- 로컬 docker MySQL에 마이그레이션 없이 수기로 들어가 있던 `task_feedback_template`/`task_feedback_template_message` id=2~5 데이터를 `V0.0.6__insert_feedback_template_test_data.sql`로 정식 반영
- 기존에 `name` 컬럼에 literal `"\n"` 문자열로 들어가 있던 값은 신규 구분자 규칙에 맞춰 `"|"`로 교체

## 기타 전달 사항

- ⚠️ 로컬 docker MySQL에는 이미 동일 id(2~5)의 `task_feedback_template`/`task_feedback_template_message` 데이터가 마이그레이션 이력 없이(Flyway 미기록) 수동으로 들어가 있어, 이 마이그레이션을 그대로 적용하면 PK 충돌이 발생합니다. 로컬에서 검증하려면 로컬 DB 리셋이 필요합니다.
- 위 사유로 로컬 통합 테스트(`RetrieveFeedbackIntegrationTest`)는 이번 PR에서 실행하지 못했습니다. 리뷰/머지 전 로컬 DB 리셋 후 실행 확인이 필요합니다.