### PR TITLE
chore: 랭킹 수집 배치 일시 비활성화

### DIFF
--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/batch/scheduler/FeedbackKingJobScheduler.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/batch/scheduler/FeedbackKingJobScheduler.java
@@ -12,7 +12,6 @@ import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -24,10 +23,11 @@ public class FeedbackKingJobScheduler {
     private final Job feedbackKingRankingJob;
 
     /**
-     * 랭킹 집계 배치 실행 트리거.
-     * 매주 월요일 02:00에 트리거하고, 마지막 월요일에만 잡을 실행한다.
+     * 랭킹 집계 배치 실행 트리거. 매주 월요일 02:00에 트리거하고, 마지막 월요일에만 잡을 실행한다.
+     * <p>
+     * TODO: 랭킹 오픈 후 스케줄러 주석 처리는 해제할 것
      */
-    @Scheduled(cron = "0 0 2 * * MON")
+    //    @Scheduled(cron = "0 0 2 * * MON")
     public void feedbackKingRankingJob() {
         LocalDateTime executionDateTime = SystemTimeUtil.now();
         if (!DateTimeUtil.isLastDayOfWeekAt(executionDateTime, DayOfWeek.MONDAY, 2)) {

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/batch/scheduler/GodsaengSilcheonreoRankingJobScheduler.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/batch/scheduler/GodsaengSilcheonreoRankingJobScheduler.java
@@ -13,7 +13,6 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -27,10 +26,11 @@ public class GodsaengSilcheonreoRankingJobScheduler {
     private final Job godsaengSilcheonreoRankingJob;
 
     /**
-     * 갓생실천러 랭킹 집계 배치 실행 트리거.
-     * 매주 월요일 02:00에 트리거하고, 마지막 월요일에만 잡을 실행한다.
+     * 갓생실천러 랭킹 집계 배치 실행 트리거. 매주 월요일 02:00에 트리거하고, 마지막 월요일에만 잡을 실행한다.
+     * <p>
+     * TODO: 랭킹 오픈 후 스케줄러 주석 처리는 해제할 것
      */
-    @Scheduled(cron = "0 0 2 * * MON")
+    //    @Scheduled(cron = "0 0 2 * * MON")
     public void runGodsaengSilcheonreoRankingJob() {
         LocalDateTime executionDateTime = SystemTimeUtil.now();
         if (!DateTimeUtil.isLastDayOfWeekAt(executionDateTime, DayOfWeek.MONDAY, 2)) {

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/batch/scheduler/JaksimSamilerRankingJobScheduler.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/batch/scheduler/JaksimSamilerRankingJobScheduler.java
@@ -13,7 +13,6 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -27,10 +26,11 @@ public class JaksimSamilerRankingJobScheduler {
     private final Job jaksimSamilerRankingJob;
 
     /**
-     * 작심삼일러 랭킹 집계 배치 실행 트리거.
-     * 매주 월요일 02:00에 트리거하고, 마지막 월요일에만 잡을 실행한다.
+     * 작심삼일러 랭킹 집계 배치 실행 트리거. 매주 월요일 02:00에 트리거하고, 마지막 월요일에만 잡을 실행한다.
+     * <p>
+     * TODO: 랭킹 오픈 후 스케줄러 주석 처리는 해제할 것
      */
-    @Scheduled(cron = "0 0 2 * * MON")
+    //    @Scheduled(cron = "0 0 2 * * MON")
     public void runJaksimSamilerRankingJob() {
         LocalDateTime executionDateTime = SystemTimeUtil.now();
         if (!DateTimeUtil.isLastDayOfWeekAt(executionDateTime, DayOfWeek.MONDAY, 2)) {


### PR DESCRIPTION
## PR 체크리스트

Merge 전에 아래 체크리스트가 모두 체크되었는지 확인해주세요

- [ ] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [ ] 모든 Test 코드를 실행하여 PASS했나요?
- [ ] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

PR의 타입을 체크해주세요

- [ ] 버그 픽스 - 이슈 링크 :
- [ ] 신규 기능 개발
- [x] 기능 수정
- [ ] 테스트 코드 추가
- [ ] 코드 스타일 업데이트 (formatting, 변수명 수정 등)
- [ ] 리팩토링 (기능 수정은 없고 코드 재사용성을 위한 메서드 분리 등)
- [ ] 설정 파일 수정
- [ ] 기타

## 백로그 및 이슈 링크

- 링크 :

## 변경된 사항

### 사항1

- 랭킹 오픈 전까지 `FeedbackKingJobScheduler`, `GodsaengSilcheonreoRankingJobScheduler`, `JaksimSamilerRankingJobScheduler`의 `@Scheduled` 크론 트리거를 주석 처리하여 배치 실행을 일시 비활성화
- 랭킹 오픈 후 주석 해제 필요하다는 TODO 주석 추가

## 기타 전달 사항

- 랭킹 오픈 시점에 3개 스케줄러의 `@Scheduled` 주석을 다시 해제해야 함