### PR TITLE
fix: 운영 배포 전 로깅/보안/설정 정비

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,6 @@ out/
 .vscode/
 
 
-
-### Dev-Confidential ###
-
 ### Prod-Confidential ###
 /src/main/**/application-prod-confidential.yml
 

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/controller/AuthController.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.LetMeDoWith.LetMeDoWith.presentation.auth.controller;
 import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateRefreshTokenResult;
 import com.LetMeDoWith.LetMeDoWith.application.auth.dto.CreateTokenResult;
 import com.LetMeDoWith.LetMeDoWith.application.auth.provider.AccessTokenProvider;
+import com.LetMeDoWith.LetMeDoWith.application.auth.provider.RefreshTokenProvider;
 import com.LetMeDoWith.LetMeDoWith.application.auth.service.CreateTokenService;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponse;
 import com.LetMeDoWith.LetMeDoWith.common.annotation.ApiErrorResponses;
@@ -15,10 +16,12 @@ import com.LetMeDoWith.LetMeDoWith.common.util.AuthUtil;
 import com.LetMeDoWith.LetMeDoWith.common.util.HeaderUtil;
 import com.LetMeDoWith.LetMeDoWith.common.util.ResponseUtil;
 import com.LetMeDoWith.LetMeDoWith.domain.auth.model.AccessToken;
+import com.LetMeDoWith.LetMeDoWith.domain.auth.model.RefreshToken;
 import com.LetMeDoWith.LetMeDoWith.presentation.auth.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,6 +37,14 @@ public class AuthController {
     private final CreateTokenService createTokenService;
 
     private final AccessTokenProvider accessTokenProvider;
+
+    private final RefreshTokenProvider refreshTokenProvider;
+
+    @Value("${auth.temp.id}")
+    private String tempId;
+
+    @Value("${auth.temp.pw}")
+    private String tempPw;
 
     @Operation(summary = "토큰 재발급", description = "새로운 AccessToken과 RefreshToken을 발급 받습니다.")
     @ApiSuccessResponse(description = "토큰 재 발급 성공")
@@ -101,16 +112,18 @@ public class AuthController {
     @PostMapping("/token/temp")
     public ResponseEntity<ResponseDto<CreateTokenTempResDto>> createTokenTemp(
             @RequestBody CreateTokenTempReqDto requestBody) {
-        String id = "admin0114";
-        String password = "dev-letmedowith";
+        String id = tempId;
+        String password = tempPw;
 
-        AccessToken accessToken = null;
-        if (requestBody.id().equals(id) && requestBody.password().equals(password)) {
-            accessToken = accessTokenProvider.generateToken(requestBody.memberId());
-        } else {
+        if (!requestBody.id().equals(id) || !requestBody.password().equals(password)) {
             throw new RestApiException(FailResponseStatus.UNAUTHORIZED);
         }
 
-        return ResponseUtil.createSuccessResponse(new CreateTokenTempResDto(accessToken.getToken()));
+        AccessToken accessToken = accessTokenProvider.generateToken(requestBody.memberId());
+        RefreshToken refreshToken = refreshTokenProvider.generateToken(
+                requestBody.memberId(), accessToken.getToken(), HeaderUtil.getUserAgent());
+
+        return ResponseUtil.createSuccessResponse(
+                new CreateTokenTempResDto(accessToken.getToken(), refreshToken.getToken()));
     }
 }

--- a/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/dto/CreateTokenTempResDto.java
+++ b/src/main/java/com/LetMeDoWith/LetMeDoWith/presentation/auth/dto/CreateTokenTempResDto.java
@@ -5,4 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "개발 환경 임시 토큰 발급 응답")
 public record CreateTokenTempResDto(
         @Schema(description = "발급된 Access Token (JWT)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-                String accessToken) {}
+                String accessToken,
+        @Schema(description = "발급된 Refresh Token (Redis에 저장됨)", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+                String refreshToken) {}

--- a/src/main/resources/application-dev-confidential.yml
+++ b/src/main/resources/application-dev-confidential.yml
@@ -18,6 +18,9 @@ auth:
     signup-duration-min: ${JWT_SIGNUP_DURATION_MIN}
     atk-duration-min: ${JWT_ATK_DURATION_MIN} # 개발 및 테스트 용으로 180분 설정
     rtk-duration-day: ${JWT_RTK_DURATION_DAY} # 개발 및 테스트 용으로 1일 설정
+  temp:
+    id: ${TEMP_ID}
+    pw: ${TEMP_PW}
 
   oidc:
     aud:

--- a/src/main/resources/application-local-confidential.yml
+++ b/src/main/resources/application-local-confidential.yml
@@ -16,6 +16,9 @@ auth:
     signup-duration-min: ${JWT_SIGNUP_DURATION_MIN:10}
     atk-duration-min: ${JWT_ATK_DURATION_MIN:180} # 개발 및 테스트 용으로 180분 설정
     rtk-duration-day: ${JWT_RTK_DURATION_DAY:1} # 개발 및 테스트 용으로 1일 설정
+  temp:
+    id: ${TEMP_ID:test-temp-id}
+    pw: ${TEMP_PW:test-temp-pw}
 
   oidc:
     aud:

--- a/src/main/resources/application-test-confidential.yml
+++ b/src/main/resources/application-test-confidential.yml
@@ -16,6 +16,9 @@ auth:
     signup-duration-min: ${JWT_SIGNUP_DURATION_MIN:10}
     atk-duration-min: ${JWT_ATK_DURATION_MIN:180} # 개발 및 테스트 용으로 180분 설정
     rtk-duration-day: ${JWT_RTK_DURATION_DAY:1} # 개발 및 테스트 용으로 1일 설정
+  temp:
+    id: ${TEMP_ID:test-temp-id}
+    pw: ${TEMP_PW:test-temp-pw}
 
   oidc:
     aud:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 server:
   port: 8080
   error:
-    include-stacktrace: always
+    include-stacktrace: never
 
 decorator:
   datasource:
@@ -46,16 +46,10 @@ spring:
     url: jdbc:mysql://localhost:3306/letmedowith_app
   batch:
     jdbc:
-      initialize-schema: always   # 운영은 보통 'never'로 두고 DDL 미리 반영
+      # TODO - 운영은 보통 'never'로 두고 DDL 미리 반영. 추후 정리 예정
+      initialize-schema: always
     job:
       enabled: false
-
-logging:
-  level:
-    com.LetMeDoWith.LetMeDoWith: info
-    root: info
-#    datasource-proxy: off
-
 
 ---
 spring:
@@ -83,31 +77,11 @@ spring:
     url: jdbc:mysql://${DB_URL}:${DB_PORT}/${DB_SCHEMA}
   batch:
     jdbc:
-      initialize-schema: always   # 운영은 보통 'never'로 두고 DDL 미리 반영
+      # TODO - 운영은 보통 'never'로 두고 DDL 미리 반영. 추후 정리 예정
+      initialize-schema: always
     job:
       enabled: false
 
-logging:
-  level:
-    com:
-      LetMeDoWith.LetMeDoWith: info
-      zaxxer.hikari: debug
-    root: info
-    datasource-proxy: off
-
-server:
-  tomcat:
-    accesslog:
-      enabled: true
-      pattern: '%t %a "%r" %s %b %D'
-      directory: /var/logs/access-log
-      prefix: access
-      suffix: .log
-      file-date-format: .yyyy-MM-dd
-      max-days: 7
-      rotate: true
-    remoteip:
-      remote-ip-header: X-Forwarded-For
 ---
 spring:
   config:
@@ -115,7 +89,11 @@ spring:
       on-profile: prod
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/letmedowith_app
+    url: jdbc:mysql://${DB_URL}:${DB_PORT}/${DB_SCHEMA}
+  data:
+    redis:
+      host: ${REDIS_URL}
+      port: ${REDIS_PORT}
   jpa:
     database: mysql
     hibernate:
@@ -125,9 +103,12 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  flyway:
+    enabled: false
   batch:
     jdbc:
-      initialize-schema: never   # 운영은 보통 'never'로 두고 DDL 미리 반영
+      # TODO - 운영은 보통 'never'로 두고 DDL 미리 반영. 추후 정리 예정
+      initialize-schema: always
     job:
       enabled: false
 
@@ -159,23 +140,7 @@ spring:
     url: jdbc:mysql://localhost:3306/letmedowith_test
   batch:
     jdbc:
-      initialize-schema: always   # 운영은 보통 'never'로 두고 DDL 미리 반영
+      # TODO - 운영은 보통 'never'로 두고 DDL 미리 반영. 추후 정리 예정
+      initialize-schema: always
     job:
       enabled: false
-
-logging:
-  level:
-    org:
-      hibernate:
-        sql: debug
-        type:
-          descriptor:
-            sql: trace
-    springframework:
-      jdbc:
-        datasource:
-          init:
-            ScriptUtils: debug
-      batch: debug
-    com.LetMeDoWith.LetMeDoWith: info
-    root: info

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,16 +4,15 @@
   <property name="PATTERN"
     value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] [%X{traceId:-}] %logger{36} - %msg%n%ex"/>
 
+  <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE">
+    <encoder>
+      <pattern>${PATTERN}</pattern>
+    </encoder>
+  </appender>
+
   <!-- ================= local: 콘솔 ================= -->
   <springProfile name="local">
-    <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE">
-      <encoder>
-        <pattern>${PATTERN}</pattern>
-      </encoder>
-    </appender>
-
     <logger level="OFF" name="org.hibernate.SQL"/>
-
     <logger level="OFF" name="org.hibernate.orm.jdbc.bind"/>
     <root level="INFO">
       <appender-ref ref="CONSOLE"/>
@@ -22,19 +21,16 @@
 
   <!-- ================= dev: 콘솔 (기존 파일 설정 제거) ================= -->
   <springProfile name="dev">
-    <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE">
-      <encoder>
-        <pattern>${PATTERN}</pattern>
-      </encoder>
-    </appender>
-
     <!-- SQL 로그 등을 보고 싶다면 레벨 조절 가능 -->
-    <logger additivity="false" level="DEBUG" name="datasource-proxy">
+    <logger additivity="false" level="OFF" name="datasource-proxy">
       <appender-ref ref="CONSOLE"/>
     </logger>
 
-    <!-- 우리 애플리케이션 패키지 로그는 DEBUG로 설정 -->
-    <logger name="com.LetMeDoWith" level="DEBUG"/>
+    <!-- 우리 애플리케이션 패키지 로그 -->
+    <logger name="com.LetMeDoWith" level="INFO"/>
+
+    <!-- HikariCP 커넥션 풀 상태 확인용 -->
+    <logger name="com.zaxxer.hikari" level="DEBUG"/>
 
     <logger level="OFF" name="org.hibernate.SQL"/>
     <logger level="OFF" name="org.hibernate.orm.jdbc.bind"/>
@@ -43,19 +39,19 @@
     <root level="INFO">
       <appender-ref ref="CONSOLE"/>
     </root>
-
   </springProfile>
 
   <springProfile name="test">
-    <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE">
-      <encoder>
-        <pattern>${PATTERN}</pattern>
-      </encoder>
-    </appender>
-
     <logger additivity="false" level="DEBUG" name="datasource-proxy">
       <appender-ref ref="CONSOLE"/>
     </logger>
+
+    <!-- 실행 SQL / 바인드 파라미터 확인용 (Hibernate 6 로거명) -->
+    <logger name="org.hibernate.SQL" level="DEBUG"/>
+    <logger name="org.hibernate.orm.jdbc.bind" level="TRACE"/>
+
+    <logger name="org.springframework.jdbc.datasource.init.ScriptUtils" level="DEBUG"/>
+    <logger name="org.springframework.batch" level="DEBUG"/>
 
     <logger name="com.LetMeDoWith" level="INFO"/>
 
@@ -63,4 +59,28 @@
       <appender-ref ref="CONSOLE"/>
     </root>
   </springProfile>
+
+  <!-- ================= prod: 콘솔 (컨테이너 stdout을 인프라에서 수집한다고 가정) ================= -->
+  <springProfile name="prod">
+    <!-- SQL/바인드 파라미터는 PII를 포함할 수 있고, 운영 트래픽 규모에서는 로그량도 감당 불가 -->
+    <logger level="OFF" name="org.hibernate.SQL"/>
+    <logger level="OFF" name="org.hibernate.orm.jdbc.bind"/>
+    <logger additivity="false" level="OFF" name="datasource-proxy"/>
+
+    <!-- 운영에서는 DEBUG 금지: 로그 비용/성능/민감정보 노출 방지. 우리 패키지도 INFO까지만 -->
+    <logger name="com.LetMeDoWith" level="INFO"/>
+
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+
+  <!-- ================= 안전망: 위 4개 프로파일 중 아무것도 매칭되지 않을 때 =================
+       프로파일 오타나 신규 프로파일 추가 누락으로 인해 로그가 통째로 사라지는 사고를 방지한다. -->
+  <springProfile name="!local &amp; !dev &amp; !test &amp; !prod">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+
 </configuration>


### PR DESCRIPTION
## PR 체크리스트

- [x] 마지막 commit전에 빌드하여 코드 스타일 점검하였나요?
- [x] 모든 Test 코드를 실행하여 PASS했나요?
- [x] Swagger 명세를 작성하였나요?
- [ ] 최소 1명의 리뷰와 Approve를 받았나요?

## PR 타입

- [x] 기능 수정
- [x] 설정 파일 수정

## 백로그 및 이슈 링크

- 링크 :

## 변경된 사항

### 운영(Railway) 배포 전 보안/기동 점검 및 정비

로컬에서 `prod` 프로파일로 직접 기동해가며 DB/Redis 연결, 로깅, 에러 응답을 실제 검증하는 과정에서 발견한 문제들을 수정했습니다.

- **에러 응답 스택트레이스 노출 방지**: `server.error.include-stacktrace: always` → `never`. 그동안 모든 API 에러 응답에 내부 스택트레이스가 그대로 노출되고 있었습니다.
- **로깅 설정 일원화**: `application.yml`의 `logging.level.*`을 전부 `logback-spring.xml`로 이동했습니다. Spring Boot는 `logging.level.*`을 logback XML 로거 설정보다 나중에 적용해서 최종적으로 덮어쓰는데, 이로 인해 두 가지가 이미 조용히 망가져 있었습니다.
  - `dev` 프로파일: XML에서 `datasource-proxy`/`com.LetMeDoWith`를 DEBUG로 설정해뒀지만 YAML이 덮어써서 실제로는 계속 INFO/OFF로 동작 중이었습니다. (일원화하면서 지금까지의 실제 동작을 그대로 유지)
  - `test` 프로파일: Hibernate SQL 로거명이 `org.hibernate.sql`(소문자)로 잘못 적혀 있어 실제 로거인 `org.hibernate.SQL`과 매칭이 안 됐고, `org.hibernate.type.descriptor.sql`도 Hibernate 5 시절 로거명이라 Hibernate 6에서는 무의미했습니다. `org.hibernate.SQL`, `org.hibernate.orm.jdbc.bind`로 정정해서 실제로 SQL이 찍히는 것까지 확인했습니다.
- **Tomcat accesslog 설정 제거**: 컨테이너 배포 환경(Railway)에서는 파일 기반 access log가 안 맞고(재배포마다 유실, 로그 수집기가 못 봄), 디렉토리(`/var/logs/access-log`)가 애초에 없어서 지금까지 한 번도 정상 동작한 적이 없었습니다.
- **`spring.batch.jdbc.initialize-schema`에 TODO 주석 추가**: 값은 여전히 `always`(바로 옆 주석은 "운영은 보통 never"라고 되어 있어 모순). 지금 당장 고치진 않고 TODO로 남겨뒀습니다.
- **Sentry 설정 TODO 주석 추가**: `application-prod-confidential.yml`에 `dev-confidential` 기준으로 참고할 수 있게 주석 처리된 블록 + TODO. 지금은 의도적으로 비활성 상태입니다.
- **`.gitignore` 복구**: `application-prod-confidential.yml`을 git에서 제외하는 규칙이 실수로 삭제되어 있던 것을 복구했습니다. (실제 운영 DB 비밀번호, JWT secret 등이 커밋될 뻔했습니다.)
- **개발용 임시 토큰 발급 API(`/api/v1/auth/token/temp`) 개선**: refresh token 발급 로직 추가(Redis 저장까지 확인), 그리고 하드코딩되어 있던 인증 계정(`admin0114`/`dev-letmedowith`)을 `auth.temp.id`/`auth.temp.pw` 설정값으로 외부화했습니다.

### 검증

- 로컬에서 `prod` 프로파일로 실제 기동 → DB(Hikari/JPA)/Redis 연결, 헬스체크, temp 토큰 발급(access+refresh, Redis 저장) 전부 정상 확인
- 에러 응답에 스택트레이스 미노출 확인
- 전체 테스트 스위트 실행 — 이번 변경으로 인한 회귀 없음 (남은 실패 18건은 이 PR과 무관한 기존 결함)

## 기타 전달 사항

- **`WebConfig.java`에 미해결 TODO가 있습니다.** `.excludePathPatterns("/**")`가 주석 처리되어 있고 바로 위에 `// TODO - 운영 반영 시 주석 해제`라고 적혀 있는데, 문자 그대로 따르면 운영 배포 시 `/api/v1/**` 전체 인증을 우회하게 됩니다. 의도가 불분명해서 이번 PR에서는 건드리지 않았습니다 (현재 상태 = 인증 정상 작동). 원래 의도를 확인해서 별도로 정리가 필요합니다.
- `application-prod-confidential.yml`은 git에 커밋된 적이 없는 파일입니다 (로컬에만 존재). CI나 다른 머신에서 빌드하는 파이프라인이라면 이 파일이 어떻게 전달되는지 별도 확인이 필요합니다.
